### PR TITLE
[teacher-ui] Sport/KBR-Hubs und Analysezugang ausbauen (Plan §6.3, §6.6, §6.9, §6.11)

### DIFF
--- a/apps/teacher-ui/src/composables/useSportBridge.ts
+++ b/apps/teacher-ui/src/composables/useSportBridge.ts
@@ -53,6 +53,7 @@ interface SportBridge {
   gradeCategoryRepository: GradeCategoryRepository
   performanceEntryRepository: PerformanceEntryRepository
   attendanceRepository: AttendanceRepository
+  toolSessionRepository: ToolSessionRepository
   tableDefinitionRepository: TableDefinitionRepository
   cooperTestConfigRepository: CooperTestConfigRepository
   shuttleRunConfigRepository: ShuttleRunConfigRepository
@@ -140,6 +141,7 @@ export function initializeSportBridge(): SportBridge {
     gradeCategoryRepository: gradeCategoryRepo,
     performanceEntryRepository: performanceEntryRepo,
     attendanceRepository: attendanceRepo,
+    toolSessionRepository: toolSessionRepo,
     tableDefinitionRepository: tableDefinitionRepo,
     cooperTestConfigRepository: cooperTestConfigRepo,
     shuttleRunConfigRepository: shuttleRunConfigRepo,
@@ -228,6 +230,7 @@ export function useSportBridge() {
     gradeCategories: computed(() => bridge.value?.gradeCategoryRepository),
     performanceEntries: computed(() => bridge.value?.performanceEntryRepository),
     attendance: computed(() => bridge.value?.attendanceRepository),
+    toolSessions: computed(() => bridge.value?.toolSessionRepository),
     tableDefinitions: computed(() => bridge.value?.tableDefinitionRepository),
 
     // Use case accessors

--- a/apps/teacher-ui/src/router/index.ts
+++ b/apps/teacher-ui/src/router/index.ts
@@ -76,6 +76,12 @@ const routes: RouteRecordRaw[] = [
     meta: { title: 'Exam Correction' }
   },
   {
+    path: '/exams/:id/analysis',
+    name: 'exam-analysis',
+    component: () => import('../views/KBRExamAnalysisPage.vue'),
+    meta: { title: 'KBR Analyse' }
+  },
+  {
     path: '/classes/:id',
     name: 'class-detail',
     component: () => import('../views/ClassDetail.vue'),

--- a/apps/teacher-ui/src/views/ExamAnalysis.vue
+++ b/apps/teacher-ui/src/views/ExamAnalysis.vue
@@ -238,7 +238,7 @@
             >
               <td>
                 <router-link
-                  :to="{ name: 'correction-compact', params: { candidateId: student.candidateId } }"
+                  :to="`/exams/${props.exam.id}/correct`"
                   class="student-link"
                 >
                   {{ getCandidateName(student.candidateId) }}

--- a/apps/teacher-ui/src/views/ExamsOverview.vue
+++ b/apps/teacher-ui/src/views/ExamsOverview.vue
@@ -33,6 +33,7 @@
         <div class="exam-actions">
           <button class="ghost" type="button" @click="editExam(exam.id)">Open</button>
           <button class="ghost" type="button" @click="openCorrection(exam.id)">Correct</button>
+          <button class="ghost" type="button" @click="openAnalysis(exam.id)">Analyze</button>
         </div>
       </article>
     </div>
@@ -66,7 +67,11 @@ const editExam = (id: string) => {
 }
 
 const openCorrection = (id: string) => {
-  router.push(`/corrections/${id}`)
+  router.push(`/exams/${id}/correct`)
+}
+
+const openAnalysis = (id: string) => {
+  router.push(`/exams/${id}/analysis`)
 }
 
 const formatStatus = (status: ExamsTypes.Exam['status']) => {

--- a/apps/teacher-ui/src/views/KBRExamAnalysisPage.vue
+++ b/apps/teacher-ui/src/views/KBRExamAnalysisPage.vue
@@ -1,0 +1,76 @@
+<template>
+  <section class="analysis-page">
+    <div v-if="loading" class="state-card">Analyse wird geladen...</div>
+    <div v-else-if="loadError" class="state-card error">{{ loadError }}</div>
+    <ExamAnalysis
+      v-else-if="exam"
+      :exam="exam"
+      :corrections="corrections"
+      :candidates="exam.candidates"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useExamsBridge } from '../composables/useExamsBridge'
+import ExamAnalysis from './ExamAnalysis.vue'
+import type { Exams as ExamsTypes } from '@viccoboard/core'
+
+const route = useRoute()
+const {
+  examRepository,
+  correctionEntryRepository
+} = useExamsBridge()
+
+const loading = ref(true)
+const loadError = ref('')
+const exam = ref<ExamsTypes.Exam | null>(null)
+const corrections = ref<ExamsTypes.CorrectionEntry[]>([])
+
+const loadData = async () => {
+  loading.value = true
+  loadError.value = ''
+
+  try {
+    const examId = String(route.params.id)
+    const loadedExam = await examRepository?.findById(examId) ?? null
+
+    if (!loadedExam) {
+      loadError.value = 'Die angeforderte Pruefung wurde nicht gefunden.'
+      return
+    }
+
+    exam.value = loadedExam
+    corrections.value = await correctionEntryRepository?.findByExam(examId) ?? []
+  } catch (error) {
+    console.error('Failed to load exam analysis page:', error)
+    loadError.value = 'Die Analyse konnte nicht geladen werden.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  loadData()
+})
+</script>
+
+<style scoped>
+.analysis-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.state-card {
+  background: white;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  padding: 1.25rem;
+}
+
+.state-card.error {
+  color: #991b1b;
+}
+</style>

--- a/apps/teacher-ui/src/views/KBRHub.vue
+++ b/apps/teacher-ui/src/views/KBRHub.vue
@@ -8,6 +8,21 @@
       <span class="summary-pill">{{ examCount }} Pruefungen</span>
     </header>
 
+    <section class="metrics-grid">
+      <article class="metric-card">
+        <strong>{{ examCount }}</strong>
+        <span>Pruefungen</span>
+      </article>
+      <article class="metric-card">
+        <strong>{{ supportTipCount }}</strong>
+        <span>Foerdertipps</span>
+      </article>
+      <article class="metric-card">
+        <strong>{{ longTermNoteCount }}</strong>
+        <span>Langzeitnotizen</span>
+      </article>
+    </section>
+
     <div class="hub-grid">
       <RouterLink class="hub-card" to="/exams">
         <p class="eyebrow">Uebersicht</p>
@@ -21,11 +36,11 @@
         <p>Direkter Einstieg in den KBR-Builder fuer einfache und komplexe Strukturen.</p>
       </RouterLink>
 
-      <article class="hub-card static-card">
-        <p class="eyebrow">Ausblick</p>
-        <h2>Foerdertipps & Export</h2>
-        <p>Diese Bereiche bleiben im KBR-Hub verankert, sobald die Navigation weiter konsolidiert wird.</p>
-      </article>
+      <RouterLink class="hub-card" :to="analysisEntry.to">
+        <p class="eyebrow">Analyse</p>
+        <h2>{{ analysisEntry.title }}</h2>
+        <p>{{ analysisEntry.description }}</p>
+      </RouterLink>
     </div>
 
     <section class="recent-panel">
@@ -45,6 +60,7 @@
           <div class="row-actions">
             <RouterLink :to="`/exams/${exam.id}`" class="ghost-link">Oeffnen</RouterLink>
             <RouterLink :to="`/exams/${exam.id}/correct`" class="ghost-link">Korrigieren</RouterLink>
+            <RouterLink :to="`/exams/${exam.id}/analysis`" class="ghost-link">Analyse</RouterLink>
           </div>
         </article>
       </div>
@@ -59,9 +75,12 @@ import { useExamsBridge } from '../composables/useExamsBridge'
 import type { Exams as ExamsTypes } from '@viccoboard/core'
 
 const { examRepository } = useExamsBridge()
+const { supportTipRepository, studentLongTermNoteRepository } = useExamsBridge()
 
 const loading = ref(true)
 const exams = ref<ExamsTypes.Exam[]>([])
+const supportTipCount = ref(0)
+const longTermNoteCount = ref(0)
 
 const examCount = computed(() => exams.value.length)
 const recentExams = computed(() =>
@@ -69,10 +88,35 @@ const recentExams = computed(() =>
     .sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime())
     .slice(0, 5)
 )
+const analysisEntry = computed(() => {
+  const exam = recentExams.value[0]
+
+  if (!exam) {
+    return {
+      to: '/exams',
+      title: 'Analyse vorbereiten',
+      description: 'Sobald Pruefungen vorhanden sind, oeffnet sich hier der direkte Weg in Statistik und Schwierigkeit.'
+    }
+  }
+
+  return {
+    to: `/exams/${exam.id}/analysis`,
+    title: 'Letzte Analyse',
+    description: `Direkt in die Analyse von ${exam.title} springen.`
+  }
+})
 
 const loadData = async () => {
   loading.value = true
-  exams.value = await examRepository?.findAll() ?? []
+  const [loadedExams, supportTips, longTermNotes] = await Promise.all([
+    examRepository?.findAll() ?? [],
+    supportTipRepository?.findAll() ?? [],
+    studentLongTermNoteRepository?.findAll() ?? []
+  ])
+
+  exams.value = loadedExams
+  supportTipCount.value = supportTips.length
+  longTermNoteCount.value = longTermNotes.length
   loading.value = false
 }
 
@@ -128,6 +172,30 @@ onMounted(() => {
   font-weight: 700;
 }
 
+.metrics-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-card {
+  background: white;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.metric-card strong {
+  font-size: 1.5rem;
+}
+
+.metric-card span {
+  color: #64748b;
+}
+
 .hub-grid {
   display: grid;
   gap: 1rem;
@@ -146,10 +214,6 @@ onMounted(() => {
   padding: 1.25rem;
   text-decoration: none;
   color: #0f172a;
-}
-
-.static-card {
-  padding: 1.25rem;
 }
 
 .eyebrow {

--- a/apps/teacher-ui/src/views/SportHub.vue
+++ b/apps/teacher-ui/src/views/SportHub.vue
@@ -8,6 +8,25 @@
       <span class="summary-pill">{{ classCount }} aktive Klassen</span>
     </header>
 
+    <section class="metrics-grid">
+      <article class="metric-card">
+        <strong>{{ gradeCategoryCount }}</strong>
+        <span>Bewertungskategorien</span>
+      </article>
+      <article class="metric-card">
+        <strong>{{ tableCount }}</strong>
+        <span>Tabellen</span>
+      </article>
+      <article class="metric-card">
+        <strong>{{ toolSessionCount }}</strong>
+        <span>Tool-Sessions</span>
+      </article>
+      <article class="metric-card">
+        <strong>{{ sportabzeichenStandardCount }}</strong>
+        <span>Sportabzeichen-Standards</span>
+      </article>
+    </section>
+
     <div class="hub-grid">
       <RouterLink v-for="entry in entries" :key="entry.to" :to="entry.to" class="hub-card">
         <p class="eyebrow">{{ entry.eyebrow }}</p>
@@ -21,11 +40,16 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
-import { useClassGroups } from '../composables/useSportBridge'
+import { getSportBridge, useClassGroups } from '../composables/useSportBridge'
 import type { ClassGroup } from '@viccoboard/core'
 
 const classGroups = useClassGroups()
+const SportBridge = getSportBridge()
 const classes = ref<ClassGroup[]>([])
+const gradeCategoryCount = ref(0)
+const tableCount = ref(0)
+const toolSessionCount = ref(0)
+const sportabzeichenStandardCount = ref(0)
 
 const entries = [
   {
@@ -64,6 +88,18 @@ const classCount = computed(() => classes.value.filter((classGroup) => !classGro
 
 onMounted(async () => {
   classes.value = await classGroups.findAll()
+
+  const [categories, tables, toolSessions, standards] = await Promise.all([
+    SportBridge.gradeCategoryRepository.findAll(),
+    SportBridge.tableDefinitionRepository.findAll(),
+    SportBridge.toolSessionRepository.findAll(),
+    SportBridge.sportabzeichenStandardRepository.findAll()
+  ])
+
+  gradeCategoryCount.value = categories.length
+  tableCount.value = tables.length
+  toolSessionCount.value = toolSessions.length
+  sportabzeichenStandardCount.value = standards.length
 })
 </script>
 
@@ -101,6 +137,30 @@ onMounted(async () => {
   background: rgba(14, 116, 144, 0.12);
   color: #155e75;
   font-weight: 700;
+}
+
+.metrics-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-card {
+  background: white;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.metric-card strong {
+  font-size: 1.5rem;
+}
+
+.metric-card span {
+  color: #64748b;
 }
 
 .hub-grid {


### PR DESCRIPTION
## Betroffene Checkboxen
- Plan.md §6.3 Fachmodule und modulare Navigationsstruktur
- Plan.md §6.6 Sport-Tools und Modultiefe sichtbar machen
- Plan.md §6.9 / §6.11 KBR-Auswertung und Analysezugang

## Was wurde umgesetzt
- Sport- und KBR-Hubs zeigen deutlich mehr Modultiefe statt nur einfacher Einstiege.
- Die KBR-Analyse ist als eigener Route-/Seiteneinstieg erreichbar.
- Sport zieht nun auch Tool-Sessions ueber die Bridge hoch, damit bestehende Modulfunktionen im Hub sichtbar werden.
- Analyse- und Navigationslinks in den KBR-Screens wurden auf den neuen IA-Stand ausgerichtet.

## Was ist bewusst nicht umgesetzt
- Der stundenbezogene Workspace-Handover folgt im naechsten gestapelten PR.
- Weitere Modul-Screens jenseits der bereits vorhandenen Domain-Funktionen bleiben unveraendert.

## Testabdeckung
- `npm test --workspace=teacher-ui`
- `npm run build --workspace=teacher-ui`

## Migrationen / Breaking Changes
- Keine.

## Manuelle Checks
- Offline-Check: nicht ausgefuehrt
- Cold-Start: nicht ausgefuehrt
- Export/Import: nicht betroffen
- iPadOS Safari Pflicht-Check: nicht ausgefuehrt
- Split View: nicht ausgefuehrt