### PR TITLE
feat(teacher-ui): mark holidays in schedule overview

### DIFF
--- a/apps/teacher-ui/src/views/ScheduleOverview.vue
+++ b/apps/teacher-ui/src/views/ScheduleOverview.vue
@@ -62,6 +62,16 @@
               <div>
                 <strong>{{ day.weekday }}</strong>
                 <span>{{ day.label }}</span>
+                <div v-if="day.markers.length > 0" class="calendar-markers">
+                  <span
+                    v-for="marker in day.markers"
+                    :key="`${day.key}-${marker.type}-${marker.label}`"
+                    class="calendar-marker"
+                    :class="`is-${marker.type}`"
+                  >
+                    {{ marker.label }}
+                  </span>
+                </div>
               </div>
               <span>{{ day.lessons.length }} Stunden</span>
             </header>
@@ -99,6 +109,10 @@ import { useClassGroups, useLessons } from '../composables/useSportBridge'
 import { getDashboardLessonState } from '../utils/dashboard-workspace'
 import type { ClassGroup, Lesson } from '@viccoboard/core'
 import { formatGermanDateTime, formatGermanTime } from '../utils/locale-format'
+import {
+  getScheduleCalendarMarkers,
+  type ResolvedScheduleCalendarMarker
+} from './schedule-calendar-markers'
 
 interface ScheduleDay {
   key: string
@@ -106,6 +120,7 @@ interface ScheduleDay {
   weekday: string
   isToday: boolean
   lessons: Lesson[]
+  markers: ResolvedScheduleCalendarMarker[]
 }
 
 const classGroups = useClassGroups()
@@ -118,6 +133,10 @@ const lessons = ref<Lesson[]>([])
 const now = ref(Date.now())
 
 const classesById = computed(() => new Map(classes.value.map((classGroup) => [classGroup.id, classGroup])))
+
+const activeStates = computed(() =>
+  Array.from(new Set(classes.value.map((classGroup) => normalizeState(classGroup.state)).filter(Boolean)))
+)
 
 const lessonState = computed(() => getDashboardLessonState(lessons.value, new Date(now.value)))
 const currentOrNextLesson = computed(() => lessonState.value.currentOrNextLesson)
@@ -145,7 +164,8 @@ const scheduleDays = computed<ScheduleDay[]>(() => {
       label: date.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' }),
       weekday: date.toLocaleDateString('de-DE', { weekday: 'long' }),
       isToday: index === 0,
-      lessons: [...dayLessons].sort(compareLessonsByStartTime)
+      lessons: [...dayLessons].sort(compareLessonsByStartTime),
+      markers: getScheduleCalendarMarkers(key, activeStates.value)
     }
   })
 })
@@ -263,6 +283,21 @@ const getDateKey = (date: Date): string => {
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
   return year + '-' + month + '-' + day
+}
+
+const normalizeState = (state: string | undefined): string => {
+  if (!state) {
+    return ''
+  }
+
+  const normalized = state.trim().toUpperCase()
+  if (normalized === 'BERLIN') {
+    return 'BE'
+  }
+  if (normalized === 'BRANDENBURG') {
+    return 'BB'
+  }
+  return normalized
 }
 
 onMounted(() => {
@@ -385,7 +420,8 @@ onMounted(() => {
 .lesson-focus,
 .week-list,
 .day-lessons,
-.mini-lesson {
+.mini-lesson,
+.calendar-markers {
   display: flex;
   flex-direction: column;
 }
@@ -398,6 +434,29 @@ onMounted(() => {
 .day-lessons,
 .mini-lesson {
   gap: 0.75rem;
+}
+
+.calendar-markers {
+  align-items: flex-start;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.calendar-marker {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+}
+
+.calendar-marker.is-holiday {
+  background: rgba(220, 38, 38, 0.1);
+  color: #991b1b;
+}
+
+.calendar-marker.is-school-break {
+  background: rgba(14, 165, 233, 0.12);
+  color: #075985;
 }
 
 .day-card.is-today {

--- a/apps/teacher-ui/src/views/schedule-calendar-markers.ts
+++ b/apps/teacher-ui/src/views/schedule-calendar-markers.ts
@@ -1,0 +1,83 @@
+type CalendarMarkerType = 'holiday' | 'school-break'
+
+export interface ScheduleCalendarMarker {
+  start: string
+  end?: string
+  label: string
+  type: CalendarMarkerType
+  states: string[]
+}
+
+export interface ResolvedScheduleCalendarMarker {
+  label: string
+  type: CalendarMarkerType
+}
+
+// Small local reference data for the first planning slice.
+// Sources checked 2026-04-26:
+// - Berlin.de: Feiertage & Schulferien, school years 2025/2026 and 2026/2027.
+// - Berlin.de: Sonn- und Feiertagsrecht for Berlin public holiday set.
+// - Brandenburg MBJS/service pages: school holidays through 2029/30.
+// - Brandenburg FTG via BRAVORS for public holiday set.
+const SCHEDULE_CALENDAR_MARKERS: ScheduleCalendarMarker[] = [
+  { start: '2026-01-01', label: 'Neujahr', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-03-08', label: 'Internationaler Frauentag', type: 'holiday', states: ['BE'] },
+  { start: '2026-04-03', label: 'Karfreitag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-04-05', label: 'Ostersonntag', type: 'holiday', states: ['BB'] },
+  { start: '2026-04-06', label: 'Ostermontag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-05-01', label: 'Tag der Arbeit', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-05-14', label: 'Christi Himmelfahrt', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-05-24', label: 'Pfingstsonntag', type: 'holiday', states: ['BB'] },
+  { start: '2026-05-25', label: 'Pfingstmontag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-10-03', label: 'Tag der Deutschen Einheit', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-10-31', label: 'Reformationstag', type: 'holiday', states: ['BB'] },
+  { start: '2026-12-25', label: '1. Weihnachtsfeiertag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2026-12-26', label: '2. Weihnachtsfeiertag', type: 'holiday', states: ['BE', 'BB'] },
+
+  { start: '2027-01-01', label: 'Neujahr', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-03-08', label: 'Internationaler Frauentag', type: 'holiday', states: ['BE'] },
+  { start: '2027-03-26', label: 'Karfreitag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-03-28', label: 'Ostersonntag', type: 'holiday', states: ['BB'] },
+  { start: '2027-03-29', label: 'Ostermontag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-05-01', label: 'Tag der Arbeit', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-05-06', label: 'Christi Himmelfahrt', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-05-16', label: 'Pfingstsonntag', type: 'holiday', states: ['BB'] },
+  { start: '2027-05-17', label: 'Pfingstmontag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-10-03', label: 'Tag der Deutschen Einheit', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-10-31', label: 'Reformationstag', type: 'holiday', states: ['BB'] },
+  { start: '2027-12-25', label: '1. Weihnachtsfeiertag', type: 'holiday', states: ['BE', 'BB'] },
+  { start: '2027-12-26', label: '2. Weihnachtsfeiertag', type: 'holiday', states: ['BE', 'BB'] },
+
+  { start: '2025-12-22', end: '2026-01-02', label: 'Weihnachtsferien', type: 'school-break', states: ['BE', 'BB'] },
+  { start: '2026-02-02', end: '2026-02-07', label: 'Winterferien', type: 'school-break', states: ['BE', 'BB'] },
+  { start: '2026-03-30', end: '2026-04-10', label: 'Osterferien', type: 'school-break', states: ['BE', 'BB'] },
+  { start: '2026-05-15', label: 'Unterrichtsfreier Tag', type: 'school-break', states: ['BE'] },
+  { start: '2026-05-26', label: 'Pfingstferien', type: 'school-break', states: ['BE', 'BB'] },
+  { start: '2026-07-09', end: '2026-08-22', label: 'Sommerferien', type: 'school-break', states: ['BE', 'BB'] },
+  { start: '2026-10-19', end: '2026-10-31', label: 'Herbstferien', type: 'school-break', states: ['BE'] },
+  { start: '2026-10-19', end: '2026-10-30', label: 'Herbstferien', type: 'school-break', states: ['BB'] },
+  { start: '2026-12-23', end: '2027-01-02', label: 'Weihnachtsferien', type: 'school-break', states: ['BE', 'BB'] },
+
+  { start: '2027-02-01', end: '2027-02-06', label: 'Winterferien', type: 'school-break', states: ['BE', 'BB'] },
+  { start: '2027-03-22', end: '2027-04-02', label: 'Osterferien', type: 'school-break', states: ['BE'] },
+  { start: '2027-03-22', end: '2027-04-03', label: 'Osterferien', type: 'school-break', states: ['BB'] },
+  { start: '2027-05-07', label: 'Unterrichtsfreier Tag', type: 'school-break', states: ['BE'] },
+  { start: '2027-05-18', end: '2027-05-19', label: 'Pfingstferien', type: 'school-break', states: ['BE'] },
+  { start: '2027-05-18', label: 'Pfingstferien', type: 'school-break', states: ['BB'] },
+  { start: '2027-07-01', end: '2027-08-14', label: 'Sommerferien', type: 'school-break', states: ['BE', 'BB'] },
+]
+
+export const getScheduleCalendarMarkers = (
+  dateKey: string,
+  states: string[]
+): ResolvedScheduleCalendarMarker[] => {
+  const normalizedStates = states.length > 0 ? states : ['BE']
+
+  return SCHEDULE_CALENDAR_MARKERS
+    .filter((marker) => isDateInMarkerRange(dateKey, marker))
+    .filter((marker) => marker.states.some((state) => normalizedStates.includes(state)))
+    .map((marker) => ({ label: marker.label, type: marker.type }))
+}
+
+const isDateInMarkerRange = (dateKey: string, marker: ScheduleCalendarMarker): boolean =>
+  dateKey >= marker.start && dateKey <= (marker.end ?? marker.start)


### PR DESCRIPTION
## Summary

Adds a small local calendar-marker reference for Berlin/Brandenburg public holidays and school breaks, then marks matching days in the existing `/schedule` overview.

## Scope

- Changes `apps/teacher-ui/src/views/ScheduleOverview.vue`
- Adds `apps/teacher-ui/src/views/schedule-calendar-markers.ts`
- No core changes
- No storage changes
- No migrations
- No dependency, lockfile, tsconfig, Jest, mock, or cross-module changes
- No external API or fetch layer

## Changes

- Adds local BE/BB marker data for 2026 and early 2027 planning ranges
- Uses class-group `state` values when available, defaulting to Berlin if no state is present
- Marks matching schedule days with holiday / school-break badges
- Keeps the view read-only: no validation blocking, no scheduler logic, no school-year setup

## Checks

- Diff checked against `main`: two allowed files changed only
- Not run locally here: build/test suite

## Notes

The marker data is deliberately local and narrow. It should be replaced or extended by a dedicated calendar data slice if broader state/year coverage becomes necessary.