### PR TITLE
feat(teacher-ui): show schedule hour grid labels

### DIFF
--- a/apps/teacher-ui/src/views/ScheduleOverview.vue
+++ b/apps/teacher-ui/src/views/ScheduleOverview.vue
@@ -91,6 +91,9 @@
                 <div>
                   <strong>{{ getLessonTitle(lesson) }}</strong>
                   <p>{{ getClassName(lesson.classGroupId) }}{{ getLessonMeta(lesson) }}</p>
+                  <p v-if="getLessonHourSlotLabel(lesson)" class="lesson-slot">
+                    {{ getLessonHourSlotLabel(lesson) }}
+                  </p>
                 </div>
                 <span>öffnen</span>
               </RouterLink>
@@ -113,6 +116,7 @@ import {
   getScheduleCalendarMarkers,
   type ResolvedScheduleCalendarMarker
 } from './schedule-calendar-markers'
+import { getScheduleHourSlot } from './schedule-hour-grid'
 
 interface ScheduleDay {
   key: string
@@ -235,6 +239,9 @@ const getLessonWorkspaceUrl = (lesson: Lesson): string =>
 const getAttendanceUrl = (lesson: Lesson): string =>
   '/attendance?classId=' + lesson.classGroupId + '&lessonId=' + lesson.id
 
+const getLessonHourSlotLabel = (lesson: Lesson): string =>
+  getScheduleHourSlot(lesson.startTime, lesson.durationMinutes)?.label ?? ''
+
 const formatLessonTime = (lesson: Lesson): string =>
   lesson.startTime || formatGermanTime(lesson.date)
 
@@ -346,7 +353,8 @@ onMounted(() => {
 .empty-text,
 .mini-lesson span,
 .day-header span,
-.lesson-row p {
+.lesson-row p,
+.lesson-slot {
   color: #64748b;
 }
 
@@ -478,6 +486,11 @@ onMounted(() => {
 
 .lesson-row div {
   flex: 1;
+}
+
+.lesson-slot {
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
 }
 
 .empty-text.compact {

--- a/apps/teacher-ui/src/views/schedule-hour-grid.ts
+++ b/apps/teacher-ui/src/views/schedule-hour-grid.ts
@@ -1,0 +1,34 @@
+export interface ScheduleHourSlot {
+  label: string
+  startTime: string
+  durationMinutes: 45 | 90
+  order: number
+}
+
+const DEFAULT_SCHEDULE_HOUR_GRID: ScheduleHourSlot[] = [
+  { label: '1. Stunde', startTime: '08:00', durationMinutes: 45, order: 1 },
+  { label: '2. Stunde', startTime: '08:50', durationMinutes: 45, order: 2 },
+  { label: '3. Stunde', startTime: '09:55', durationMinutes: 45, order: 3 },
+  { label: '4. Stunde', startTime: '10:45', durationMinutes: 45, order: 4 },
+  { label: '5. Stunde', startTime: '11:50', durationMinutes: 45, order: 5 },
+  { label: '6. Stunde', startTime: '12:40', durationMinutes: 45, order: 6 },
+  { label: '7. Stunde', startTime: '13:30', durationMinutes: 45, order: 7 },
+  { label: '8. Stunde', startTime: '14:20', durationMinutes: 45, order: 8 },
+  { label: '1./2. Stunde', startTime: '08:00', durationMinutes: 90, order: 1 },
+  { label: '3./4. Stunde', startTime: '09:55', durationMinutes: 90, order: 3 },
+  { label: '5./6. Stunde', startTime: '11:50', durationMinutes: 90, order: 5 },
+  { label: '7./8. Stunde', startTime: '13:30', durationMinutes: 90, order: 7 }
+]
+
+export const getScheduleHourSlot = (
+  startTime: string | undefined,
+  durationMinutes: number | undefined
+): ScheduleHourSlot | null => {
+  if (!startTime || !durationMinutes) {
+    return null
+  }
+
+  return DEFAULT_SCHEDULE_HOUR_GRID.find((slot) =>
+    slot.startTime === startTime && slot.durationMinutes === durationMinutes
+  ) ?? null
+}


### PR DESCRIPTION
## Summary

Adds a small local hour-grid reference and uses it to label existing lessons in the `/schedule` overview.

## Dependency

This branch is built on top of #260 (`assistant/schedule-calendar-markers`) because both slices touch `ScheduleOverview.vue`.

Please merge #260 first, then this PR should be rechecked/rebased before merge.

## Scope

- Changes `apps/teacher-ui/src/views/ScheduleOverview.vue`
- Adds `apps/teacher-ui/src/views/schedule-hour-grid.ts`
- Includes #260 changes until #260 is merged into `main`
- No core changes
- No storage changes
- No migrations
- No editable grid configuration
- No dependency, lockfile, tsconfig, Jest, mock, or cross-module changes

## Changes

- Adds a small default hour-grid reference with 45- and 90-minute slots
- Shows the matching slot label below each lesson when `startTime` and `durationMinutes` match a known slot
- Leaves non-matching lessons visible and unchanged

## Checks

- Diff checked against #260 base commit: only `ScheduleOverview.vue` and `schedule-hour-grid.ts` changed
- Not run locally here: build/test suite