### PR TITLE
feat(students): add class school-year copy use case

### DIFF
--- a/modules/students/src/index.ts
+++ b/modules/students/src/index.ts
@@ -32,5 +32,11 @@ export type {
   StudentImportPreview,
   StudentImportExecutionResult
 } from './use-cases/student-csv-import.use-case.js';
+export { CopyClassGroupToSchoolYearUseCase } from './use-cases/copy-class-group-to-school-year.use-case.js';
+export type {
+  CopyClassGroupGateway,
+  CopyClassGroupToSchoolYearInput,
+  CopyClassGroupToSchoolYearResult
+} from './use-cases/copy-class-group-to-school-year.use-case.js';
 
 export const STUDENTS_MODULE_VERSION = '0.1.0';

--- a/modules/students/src/use-cases/copy-class-group-to-school-year.use-case.ts
+++ b/modules/students/src/use-cases/copy-class-group-to-school-year.use-case.ts
@@ -1,10 +1,9 @@
 import type { ClassGroup, Student } from '@viccoboard/core';
+import type { ClassGroupGateway } from './student-csv-import.use-case.js';
 import { StudentRepository } from '../repositories/student.repository.js';
 
-export interface CopyClassGroupGateway {
+export interface CopyClassGroupGateway extends ClassGroupGateway {
   getById(id: string): Promise<ClassGroup | null>;
-  findBySchoolYear(schoolYear: string): Promise<ClassGroup[]>;
-  create(input: Omit<ClassGroup, 'id' | 'createdAt' | 'lastModified'>): Promise<ClassGroup>;
 }
 
 export interface CopyClassGroupToSchoolYearInput {

--- a/modules/students/src/use-cases/copy-class-group-to-school-year.use-case.ts
+++ b/modules/students/src/use-cases/copy-class-group-to-school-year.use-case.ts
@@ -1,0 +1,110 @@
+import type { ClassGroup, Student } from '@viccoboard/core';
+import { StudentRepository } from '../repositories/student.repository.js';
+
+export interface CopyClassGroupGateway {
+  getById(id: string): Promise<ClassGroup | null>;
+  findBySchoolYear(schoolYear: string): Promise<ClassGroup[]>;
+  create(input: Omit<ClassGroup, 'id' | 'createdAt' | 'lastModified'>): Promise<ClassGroup>;
+}
+
+export interface CopyClassGroupToSchoolYearInput {
+  sourceClassGroupId: string;
+  targetSchoolYear: string;
+  targetClassName?: string;
+}
+
+export interface CopyClassGroupToSchoolYearResult {
+  classGroup: ClassGroup;
+  copiedStudents: number;
+  skippedStudents: number;
+}
+
+export class CopyClassGroupToSchoolYearUseCase {
+  constructor(
+    private studentRepository: StudentRepository,
+    private classGroupGateway: CopyClassGroupGateway
+  ) {}
+
+  async execute(input: CopyClassGroupToSchoolYearInput): Promise<CopyClassGroupToSchoolYearResult> {
+    const sourceClassGroupId = input.sourceClassGroupId.trim();
+    const targetSchoolYear = input.targetSchoolYear.trim();
+    const targetClassName = input.targetClassName?.trim();
+
+    if (!sourceClassGroupId) {
+      throw new Error('sourceClassGroupId is required');
+    }
+
+    if (!this.isValidSchoolYear(targetSchoolYear)) {
+      throw new Error('targetSchoolYear must use YYYY/YYYY format');
+    }
+
+    const sourceClassGroup = await this.classGroupGateway.getById(sourceClassGroupId);
+    if (!sourceClassGroup) {
+      throw new Error('Source class group not found');
+    }
+
+    const className = targetClassName || sourceClassGroup.name;
+    const targetClassGroup = await this.createTargetClassGroup(sourceClassGroup, className, targetSchoolYear);
+    const students = await this.studentRepository.findByClassGroup(sourceClassGroup.id);
+
+    let copiedStudents = 0;
+    for (const student of students) {
+      await this.copyStudent(student, targetClassGroup.id);
+      copiedStudents += 1;
+    }
+
+    return {
+      classGroup: targetClassGroup,
+      copiedStudents,
+      skippedStudents: 0
+    };
+  }
+
+  private async createTargetClassGroup(
+    sourceClassGroup: ClassGroup,
+    targetClassName: string,
+    targetSchoolYear: string
+  ): Promise<ClassGroup> {
+    const existingTargetClassGroup = (await this.classGroupGateway.findBySchoolYear(targetSchoolYear))
+      .find((classGroup) => classGroup.name.trim().toLowerCase() === targetClassName.toLowerCase());
+
+    if (existingTargetClassGroup) {
+      throw new Error('Target class group already exists');
+    }
+
+    return this.classGroupGateway.create({
+      name: targetClassName,
+      schoolYear: targetSchoolYear,
+      color: sourceClassGroup.color,
+      archived: false,
+      state: sourceClassGroup.state,
+      holidayCalendarRef: sourceClassGroup.holidayCalendarRef,
+      gradingScheme: sourceClassGroup.gradingScheme,
+      subjectProfile: sourceClassGroup.subjectProfile
+    });
+  }
+
+  private async copyStudent(student: Student, targetClassGroupId: string): Promise<void> {
+    await this.studentRepository.create({
+      firstName: student.firstName,
+      lastName: student.lastName,
+      dateOfBirth: student.dateOfBirth,
+      gender: student.gender,
+      photoUri: student.photoUri,
+      contactInfo: student.contactInfo,
+      classGroupId: targetClassGroupId,
+      legacyDateOfBirthMissing: student.legacyDateOfBirthMissing
+    });
+  }
+
+  private isValidSchoolYear(schoolYear: string): boolean {
+    const match = /^(\d{4})\/(\d{4})$/.exec(schoolYear);
+    if (!match) {
+      return false;
+    }
+
+    const startYear = Number(match[1]);
+    const endYear = Number(match[2]);
+    return endYear === startYear + 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a small use case for copying one existing class group into a target school year, including student master data.

## Scope

- Adds `modules/students/src/use-cases/copy-class-group-to-school-year.use-case.ts`
- Exports the use case from `modules/students/src/index.ts`
- No UI
- No migration
- No new tables
- No core changes
- No storage changes
- No Lessons / Attendance / Grades / Exams copy
- No dependency, lockfile, tsconfig, Jest, mock, or cross-module changes

## Changes

- Introduces `CopyClassGroupToSchoolYearUseCase`
- Uses a small `CopyClassGroupGateway`, following the gateway style already used by the student CSV import use case
- Validates `sourceClassGroupId` and `targetSchoolYear`
- Fails if the source class group does not exist
- Fails if the target class name already exists in the target school year
- Creates a target class group using selected metadata from the source class group
- Copies only student master data into the target class group with new student records

## Checks

- Diff checked against `main`: two allowed files changed only
- Not run locally here: build/test suite

## Notes

This is intentionally use-case only. A later UI slice can wire this into `ClassesOverview.vue` or `ClassDetail.vue`.