### PR TITLE
fix(teacher-ui): complete lesson parts form integration

### DIFF
--- a/apps/teacher-ui/src/views/LessonList.vue
+++ b/apps/teacher-ui/src/views/LessonList.vue
@@ -261,6 +261,12 @@ const dateTo = ref<string>('')
 const showCreateLessonModal = ref(false)
 const showEditLessonModal = ref(false)
 
+interface LessonPartForm {
+  description: string
+  duration: string
+  type: string
+}
+
 interface LessonForm {
   id?: string
   classGroupId: string
@@ -269,16 +275,22 @@ interface LessonForm {
   durationMinutes: 45 | 90
   title: string
   room: string
+  shortcuts: string
+  lessonParts: LessonPartForm[]
 }
 
-const lessonForm = ref<LessonForm>({
-  classGroupId: '',
+const getInitialLessonForm = (): LessonForm => ({
+  classGroupId: selectedClassId.value || '',
   date: new Date().toISOString().split('T')[0],
   startTime: '08:00',
   durationMinutes: 45,
   title: '',
-  room: ''
+  room: '',
+  shortcuts: '',
+  lessonParts: []
 })
+
+const lessonForm = ref<LessonForm>(getInitialLessonForm())
 
 // Computed
 const filteredLessons = computed(() => {
@@ -371,7 +383,13 @@ const handleEditLesson = async (lesson: Lesson) => {
     startTime: lesson.startTime || lesson.date.toTimeString().split(' ')[0].substring(0, 5),
     durationMinutes: lesson.durationMinutes,
     title: lesson.title || '',
-    room: lesson.room || ''
+    room: lesson.room || '',
+    shortcuts: (lesson.shortcuts ?? []).join(', '),
+    lessonParts: parts.map((part) => ({
+      description: part.description,
+      duration: part.duration !== undefined ? String(part.duration) : '',
+      type: part.type ?? ''
+    }))
   }
   showEditLessonModal.value = true
 }
@@ -397,6 +415,14 @@ const handleSaveLesson = async () => {
   try {
     // Combine date and time for the lesson date field
     const dateTime = new Date(`${lessonForm.value.date}T${lessonForm.value.startTime}:00`)
+    const shortcuts = parseShortcuts(lessonForm.value.shortcuts)
+    const partsInput = lessonForm.value.lessonParts
+      .filter((part) => part.description.trim().length > 0)
+      .map((part) => ({
+        description: part.description.trim(),
+        duration: part.duration ? Number(part.duration) : undefined,
+        type: part.type.trim() || undefined
+      }))
 
     if (showEditLessonModal.value && lessonForm.value.id) {
       // Update existing lesson via validated use-case
@@ -406,7 +432,8 @@ const handleSaveLesson = async () => {
         startTime: lessonForm.value.startTime,
         durationMinutes: lessonForm.value.durationMinutes,
         title: lessonForm.value.title.trim() || undefined,
-        room: lessonForm.value.room.trim() || undefined
+        room: lessonForm.value.room.trim() || undefined,
+        shortcuts
       })
       await SportBridge.lessonPartRepository.replacePartsForLesson(lessonForm.value.id, partsInput)
     } else {
@@ -417,7 +444,8 @@ const handleSaveLesson = async () => {
         startTime: lessonForm.value.startTime,
         durationMinutes: lessonForm.value.durationMinutes,
         title: lessonForm.value.title.trim() || undefined,
-        room: lessonForm.value.room.trim() || undefined
+        room: lessonForm.value.room.trim() || undefined,
+        shortcuts
       })
       await SportBridge.lessonPartRepository.replacePartsForLesson(created.id, partsInput)
     }
@@ -440,15 +468,14 @@ const closeModals = () => {
   showCreateLessonModal.value = false
   showEditLessonModal.value = false
   saveError.value = ''
-  lessonForm.value = {
-    classGroupId: selectedClassId.value || '',
-    date: new Date().toISOString().split('T')[0],
-    startTime: '08:00',
-    durationMinutes: 45,
-    title: '',
-    room: ''
-  }
+  lessonForm.value = getInitialLessonForm()
 }
+
+const parseShortcuts = (value: string): string[] =>
+  value
+    .split(',')
+    .map((shortcut) => shortcut.trim())
+    .filter((shortcut) => shortcut.length > 0)
 
 const getClassName = (classGroupId: string): string => {
   const cls = classes.value.find(c => c.id === classGroupId)

--- a/modules/sport/src/use-cases/update-lesson.use-case.ts
+++ b/modules/sport/src/use-cases/update-lesson.use-case.ts
@@ -16,6 +16,7 @@ export interface UpdateLessonInput {
   durationMinutes?: 45 | 90;
   title?: string;
   room?: string;
+  shortcuts?: string[];
 }
 
 export class UpdateLessonUseCase {
@@ -30,6 +31,7 @@ export class UpdateLessonUseCase {
     if (input.durationMinutes !== undefined) updates.durationMinutes = input.durationMinutes;
     if (input.title !== undefined) updates.title = input.title;
     if (input.room !== undefined) updates.room = input.room;
+    if (input.shortcuts !== undefined) updates.shortcuts = input.shortcuts;
 
     return this.lessonRepo.update(input.lessonId, updates);
   }


### PR DESCRIPTION
## Summary

Completes the LessonList form integration for lesson parts and shortcuts.

## Scope

- Updates `apps/teacher-ui/src/views/LessonList.vue`
- Updates `modules/sport/src/use-cases/update-lesson.use-case.ts`
- No dependency, lockfile, tsconfig, Jest, mock, storage, migration, or cross-module changes

## Changes

- Adds `shortcuts` to `UpdateLessonInput`
- Persists shortcuts through `UpdateLessonUseCase`
- Extends LessonList form state with `shortcuts` and `lessonParts`
- Builds lesson-part input from the form state before save
- Loads existing lesson parts and shortcuts into the edit form
- Keeps lesson timing updates on the validated use-case path

## Checks

- Diff checked against `main`: two files changed only
- Not run locally here: build/typecheck/test suite