### PR TITLE
Fix exam template reuse, sheet assets and dev script

### DIFF
--- a/apps/teacher-ui/src/components/CorrectionSheetPresetForm.vue
+++ b/apps/teacher-ui/src/components/CorrectionSheetPresetForm.vue
@@ -53,6 +53,36 @@
       ></textarea>
     </div>
 
+    <div class="form-row">
+      <div class="form-group">
+        <label for="preset-school-logo">Schullogo</label>
+        <input
+          id="preset-school-logo"
+          type="file"
+          accept="image/png,image/jpeg"
+          @change="uploadImage('schoolLogo', $event)"
+        />
+        <div v-if="modelValue.schoolLogo" class="image-preview-row">
+          <span>{{ modelValue.schoolLogo.fileName ?? 'Logo hochgeladen' }}</span>
+          <button type="button" class="small-button" @click="clearImage('schoolLogo')">Entfernen</button>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="preset-teacher-signature">Gescannte Unterschrift</label>
+        <input
+          id="preset-teacher-signature"
+          type="file"
+          accept="image/png,image/jpeg"
+          @change="uploadImage('teacherSignature', $event)"
+        />
+        <div v-if="modelValue.teacherSignature" class="image-preview-row">
+          <span>{{ modelValue.teacherSignature.fileName ?? 'Unterschrift hochgeladen' }}</span>
+          <button type="button" class="small-button" @click="clearImage('teacherSignature')">Entfernen</button>
+        </div>
+      </div>
+    </div>
+
     <div class="form-group">
       <label for="preset-footer-text">Footer-Text</label>
       <textarea
@@ -96,6 +126,48 @@ function updateField<Key extends keyof Exams.CorrectionSheetPreset>(
     [key]: value,
     updatedAt: new Date()
   });
+}
+
+function readImageFile(file: File): Promise<Exams.CorrectionSheetImage> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== 'string') {
+        reject(new Error('Bild konnte nicht gelesen werden.'));
+        return;
+      }
+
+      resolve({
+        src: reader.result,
+        fileName: file.name
+      });
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Bild konnte nicht gelesen werden.'));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function uploadImage(
+  key: 'schoolLogo' | 'teacherSignature',
+  event: Event
+): Promise<void> {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) {
+    return;
+  }
+
+  if (!['image/png', 'image/jpeg'].includes(file.type)) {
+    input.value = '';
+    return;
+  }
+
+  updateField(key, await readImageFile(file));
+  input.value = '';
+}
+
+function clearImage(key: 'schoolLogo' | 'teacherSignature'): void {
+  updateField(key, undefined);
 }
 </script>
 
@@ -151,6 +223,23 @@ function updateField<Key extends keyof Exams.CorrectionSheetPreset>(
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 14px;
   background: #f8fafc;
+}
+
+.image-preview-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.small-button {
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  border-radius: 999px;
+  background: transparent;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
 }
 
 textarea {

--- a/apps/teacher-ui/src/components/SimpleExamBuilderForm.vue
+++ b/apps/teacher-ui/src/components/SimpleExamBuilderForm.vue
@@ -390,6 +390,16 @@ const candidatesAreValid = computed(() =>
   formData.candidates.every(candidate => candidate.firstName.trim() && candidate.lastName.trim())
 );
 
+const hasValidationErrors = computed(() => {
+  if (errors.title) {
+    return true;
+  }
+
+  return errors.tasks?.some((taskError) =>
+    Boolean(taskError?.title || taskError?.points || taskError?.bonusPoints)
+  ) ?? false;
+});
+
 const canSave = computed(() => {
   return (
     formData.title.trim().length > 0 &&
@@ -398,7 +408,7 @@ const canSave = computed(() => {
     formData.tasks.every(
       task => task.title?.trim().length > 0 && task.points >= 0
     ) &&
-    !Object.values(errors).some(e => e !== undefined)
+    !hasValidationErrors.value
   );
 });
 
@@ -602,6 +612,7 @@ const saveExam = async () => {
       date: formData.date ? new Date(`${formData.date}T00:00:00`) : undefined,
       assessmentFormat: 'klausur',
       mode: 'simple' as Exams.ExamMode,
+      kind: 'template',
       structure: {
         parts: [],
         tasks,

--- a/apps/teacher-ui/src/stores/examBuilderStore.ts
+++ b/apps/teacher-ui/src/stores/examBuilderStore.ts
@@ -61,6 +61,7 @@ export const useExamBuilderStore = defineStore('examBuilder', () => {
   const isEditing = ref(false)
   const createdAt = ref<Date | null>(null)
   const examId = ref<string | undefined>(undefined)
+  const sourceTemplateId = ref<string | undefined>(undefined)
 
   // ============ Getters ============
   const flatTasks = computed(() => flattenTasks(tasks.value))
@@ -246,6 +247,8 @@ export const useExamBuilderStore = defineStore('examBuilder', () => {
       classGroupId: classGroupId.value.trim() || undefined,
       assessmentFormat: assessmentFormat.value,
       mode: mode.value as ExamsTypes.ExamMode,
+      kind: 'template',
+      sourceTemplateId: sourceTemplateId.value,
       structure: {
         parts: parts.value.map((part, index) => ({
           id: part.id,
@@ -294,6 +297,7 @@ export const useExamBuilderStore = defineStore('examBuilder', () => {
     examId.value = exam.id
     isEditing.value = true
     createdAt.value = exam.createdAt
+    sourceTemplateId.value = exam.sourceTemplateId
     title.value = exam.title
     description.value = exam.description ?? ''
     classGroupId.value = exam.classGroupId ?? ''
@@ -429,6 +433,7 @@ export const useExamBuilderStore = defineStore('examBuilder', () => {
     examId.value = undefined
     isEditing.value = false
     createdAt.value = null
+    sourceTemplateId.value = undefined
     title.value = ''
     description.value = ''
     classGroupId.value = ''
@@ -452,6 +457,7 @@ export const useExamBuilderStore = defineStore('examBuilder', () => {
     isEditing,
     createdAt,
     examId,
+    sourceTemplateId,
 
     // Getters
     flatTasks,

--- a/apps/teacher-ui/src/views/ExamsOverview.vue
+++ b/apps/teacher-ui/src/views/ExamsOverview.vue
@@ -28,10 +28,12 @@
         <div class="exam-meta">
           <span>{{ exam.structure.tasks.length }} Aufgaben</span>
           <span>{{ exam.structure.totalPoints }} Punkte</span>
+          <span v-if="exam.candidates.length === 0">Vorlage</span>
           <span class="meta-date">Aktualisiert {{ formatDate(exam.lastModified) }}</span>
         </div>
         <div class="exam-actions">
           <button class="ghost" type="button" @click="editExam(exam.id)">Öffnen</button>
+          <button class="ghost" type="button" @click="copyExam(exam)">Als Kopie verwenden</button>
           <button class="ghost" type="button" @click="openCorrection(exam.id)">Korrigieren</button>
           <button class="ghost" type="button" @click="openAnalysis(exam.id)">Analysieren</button>
           <button class="ghost" type="button" @click="openExport(exam.id)">Exportieren</button>
@@ -66,6 +68,25 @@ const createNew = () => {
 
 const editExam = (id: string) => {
   router.push(`/exams/${id}`)
+}
+
+const copyExam = async (exam: ExamsTypes.Exam) => {
+  if (!examRepository) return
+
+  const { id: _id, createdAt: _createdAt, lastModified: _lastModified, ...copyInput } = exam
+  const copy = await examRepository.create({
+    ...copyInput,
+    title: `${exam.title} (Kopie)`,
+    date: undefined,
+    classGroupId: undefined,
+    kind: 'template',
+    sourceTemplateId: exam.id,
+    candidates: [],
+    candidateGroups: [],
+    status: 'draft'
+  })
+
+  router.push(`/exams/${copy.id}`)
 }
 
 const openCorrection = (id: string) => {
@@ -217,15 +238,3 @@ onMounted(() => {
   min-height: 44px;
 }
 </style>
-
-
-
-
-
-
-
-
-
-
-
-

--- a/modules/exams/src/services/pdf/correction-sheet-pdf.renderer.ts
+++ b/modules/exams/src/services/pdf/correction-sheet-pdf.renderer.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, StandardFonts, rgb, type PDFPage, type PDFFont } from 'pdf-lib';
+import { PDFDocument, StandardFonts, rgb, type PDFImage, type PDFPage, type PDFFont } from 'pdf-lib';
 import { Exams } from '@viccoboard/core';
 
 const PAGE_MARGIN = 40;
@@ -57,6 +57,40 @@ function wrapText(text: string, maxWidth: number, font: PDFFont, fontSize: numbe
   return lines;
 }
 
+function readDataUrlBytes(src: string): Uint8Array | null {
+  const match = src.match(/^data:image\/(png|jpeg|jpg);base64,(.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const binary = atob(match[2]);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+async function embedImage(
+  document: PDFDocument,
+  image?: Exams.CorrectionSheetImage
+): Promise<PDFImage | null> {
+  if (!image?.src) {
+    return null;
+  }
+
+  const bytes = readDataUrlBytes(image.src);
+  if (!bytes) {
+    return null;
+  }
+
+  if (image.src.startsWith('data:image/png;')) {
+    return document.embedPng(bytes);
+  }
+
+  return document.embedJpg(bytes);
+}
+
 export class CorrectionSheetPdfRenderer {
   async render(
     projections: Exams.CorrectionSheetProjection[],
@@ -90,6 +124,8 @@ export class CorrectionSheetPdfRenderer {
     let page = document.addPage();
     let { width, height } = page.getSize();
     let cursorY = height - PAGE_MARGIN;
+    const logoImage = await embedImage(document, projection.schoolLogo);
+    const signatureImage = await embedImage(document, projection.teacherSignature);
 
     const ensureSpace = (requiredHeight: number): void => {
       if (cursorY - requiredHeight >= PAGE_MARGIN) {
@@ -137,6 +173,16 @@ export class CorrectionSheetPdfRenderer {
     };
 
     if (projection.showHeader) {
+      if (logoImage) {
+        const scaled = logoImage.scaleToFit(110, 48);
+        page.drawImage(logoImage, {
+          x: width - PAGE_MARGIN - scaled.width,
+          y: cursorY - scaled.height + 6,
+          width: scaled.width,
+          height: scaled.height
+        });
+      }
+
       drawTextLine(projection.examTitle, { size: TITLE_FONT_SIZE, font: boldFont });
 
       const metaBits = [
@@ -222,14 +268,25 @@ export class CorrectionSheetPdfRenderer {
     }
 
     if (projection.showSignatureArea) {
-      ensureSpace(50);
+      ensureSpace(70);
       drawTextLine('Unterschrift', { font: boldFont });
+
+      if (signatureImage) {
+        const scaled = signatureImage.scaleToFit(180, 42);
+        page.drawImage(signatureImage, {
+          x: PAGE_MARGIN,
+          y: cursorY - scaled.height,
+          width: scaled.width,
+          height: scaled.height
+        });
+      }
+
       page.drawLine({
         start: { x: PAGE_MARGIN, y: cursorY - 8 },
         end: { x: PAGE_MARGIN + 180, y: cursorY - 8 },
         thickness: 0.8
       });
-      cursorY -= 28;
+      cursorY -= 48;
     }
 
     if (projection.footerText) {

--- a/modules/exams/src/use-cases/build-correction-sheet-projection.use-case.ts
+++ b/modules/exams/src/use-cases/build-correction-sheet-projection.use-case.ts
@@ -109,6 +109,8 @@ export class BuildCorrectionSheetProjectionUseCase {
       generalComment: resolveGeneralComment(correction, preset),
       headerText: preset.headerText,
       footerText: preset.footerText,
+      schoolLogo: preset.schoolLogo,
+      teacherSignature: preset.teacherSignature,
       layoutMode: preset.layoutMode,
       showHeader: preset.showHeader,
       showOverallPoints: preset.showOverallPoints,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "apps/*"
   ],
   "scripts": {
-    "dev": "npm run build:packages && npm run dev --workspace=teacher-ui",
+    "dev": "npm run dev --workspace=teacher-ui",
     "dev:ui": "npm run dev --workspace=teacher-ui",
     "test": "npm run test --workspace=@viccoboard/storage --workspace=@viccoboard/students --workspace=@viccoboard/exams --workspace=@viccoboard/sport --workspace=teacher-ui",
     "build": "npm run build:all",

--- a/packages/core/src/interfaces/exam/correction-sheet.types.ts
+++ b/packages/core/src/interfaces/exam/correction-sheet.types.ts
@@ -1,5 +1,10 @@
 export type CorrectionSheetLayoutMode = 'compact' | 'standard';
 
+export interface CorrectionSheetImage {
+  src: string;
+  fileName?: string;
+}
+
 export interface CorrectionSheetPreset {
   id: string;
   examId: string;
@@ -15,6 +20,8 @@ export interface CorrectionSheetPreset {
   showSignatureArea: boolean;
   headerText?: string;
   footerText?: string;
+  schoolLogo?: CorrectionSheetImage;
+  teacherSignature?: CorrectionSheetImage;
   updatedAt: Date;
 }
 
@@ -47,6 +54,8 @@ export interface CorrectionSheetProjection {
   generalComment?: string;
   headerText?: string;
   footerText?: string;
+  schoolLogo?: CorrectionSheetImage;
+  teacherSignature?: CorrectionSheetImage;
   layoutMode: CorrectionSheetLayoutMode;
   showHeader: boolean;
   showOverallPoints: boolean;

--- a/packages/core/src/interfaces/exam/exam-structure.types.ts
+++ b/packages/core/src/interfaces/exam/exam-structure.types.ts
@@ -12,7 +12,7 @@ export interface Exam {
   classGroupId?: string;
   assessmentFormat: ExamAssessmentFormat;
   mode: ExamMode;
-  kind: ExamKind;
+  kind?: ExamKind;
   sourceTemplateId?: string;
   structure: ExamStructure;
   gradingKey: GradingKey;

--- a/packages/core/src/interfaces/exam/exam-structure.types.ts
+++ b/packages/core/src/interfaces/exam/exam-structure.types.ts
@@ -12,6 +12,8 @@ export interface Exam {
   classGroupId?: string;
   assessmentFormat: ExamAssessmentFormat;
   mode: ExamMode;
+  kind: ExamKind;
+  sourceTemplateId?: string;
   structure: ExamStructure;
   gradingKey: GradingKey;
   printPresets: PrintPreset[];
@@ -21,6 +23,8 @@ export interface Exam {
   createdAt: Date;
   lastModified: Date;
 }
+
+export type ExamKind = 'template' | 'exam';
 
 export type ExamAssessmentFormat =
   | 'klausur'


### PR DESCRIPTION
## DONE
- Fixed the concrete save blocker for simple exams without candidates: empty task error containers no longer block `canSave`.
- Complex exams are saved as reusable template-style exams by default (`kind: 'template'`) while remaining backward-compatible because the field is optional.
- Added `sourceTemplateId` metadata for copied exams.
- Added overview action `Als Kopie verwenden`:
  - creates a new exam from an existing one
  - removes date, class link, candidates and candidate groups
  - keeps structure, criteria, grading and print preset data
  - opens the copy directly for editing
- Added PNG/JPEG upload fields for Schullogo and scanned teacher signature in the correction sheet preset form.
- Persisted these images through the existing correction-sheet preset metadata path.
- Passed uploaded images into correction-sheet projections.
- Rendered logo and signature in existing pdf-lib correction sheet renderer.
- Removed the pre-dev `build:packages` step from root `npm run dev`; it now delegates directly to `teacher-ui`.
- No new dependencies.

## NOT DONE
- No full WYSIWYG layout editor.
- No new asset repository or file-storage abstraction.
- No database migration for template metadata; `kind` and `sourceTemplateId` stay optional. Follow-up may add explicit persistence columns if needed beyond IndexedDB/current payload behavior.
- No automatic student/class instantiation flow in this slice.

## CHECKS
- Repo paths checked before patching: Simple builder, complex builder store, exams overview, correction sheet preset form, projection use case, PDF renderer, core exam/correction-sheet types, root package scripts.
- Scope check: changed 9 existing files only.
- Local tests were not run in this environment.
- This PR is intentionally draft until CI/typecheck/test run confirms the TypeScript surface, especially optional template metadata, `CorrectionSheetImage` usage and browser availability of `atob` in the PDF renderer path.

## READY FOR NEXT STEP
NOT DONE - draft PR. Run CI/typecheck/tests, then review whether optional template metadata should get a follow-up persistence migration.