### PR TITLE
Fix KBR exam save without candidates

### DIFF
--- a/apps/teacher-ui/src/views/KBRExamBuilder.vue
+++ b/apps/teacher-ui/src/views/KBRExamBuilder.vue
@@ -75,7 +75,7 @@
             <p v-if="store.classGroupId">
               {{ classStudents.length }} Schüler in {{ selectedClassLabel }}
             </p>
-            <p v-else>Wählen Sie oben eine Klasse aus, um Schüler oder komplette Klassen zu übernehmen.</p>
+            <p v-else>Optional: Wählen Sie eine Klasse aus, um Schüler oder komplette Klassen zu übernehmen.</p>
           </div>
           <div class="import-actions">
             <button
@@ -111,7 +111,7 @@
         </div>
 
         <div v-if="candidates.length === 0" class="empty-state">
-          Noch keine Kandidaten. Für die Korrektur und den PDF-Export wird mindestens ein Prüfling benötigt.
+          Noch keine Kandidaten. Die Prüfung kann als Vorlage gespeichert werden; für Korrektur und PDF-Export fügen Sie später Prüflinge hinzu.
         </div>
 
         <div v-else class="candidate-list">
@@ -402,11 +402,14 @@ const availableImportStudents = computed(() => {
 });
 
 const canSave = computed(() => {
-  const hasValidCandidates = candidates.value.length > 0 &&
-    candidates.value.every((candidate) => candidate.firstName.trim() && candidate.lastName.trim());
-  const hasValidGroups = store.assessmentFormat !== 'gruppenarbeit' || store.candidateGroups.every((group: Exams.CandidateGroup) =>
-    group.name.trim().length > 0 && group.memberCandidateIds.length > 0
+  const hasValidCandidates = candidates.value.every((candidate) =>
+    candidate.firstName.trim() && candidate.lastName.trim()
   );
+  const hasValidGroups = candidates.value.length === 0 ||
+    store.assessmentFormat !== 'gruppenarbeit' ||
+    store.candidateGroups.every((group: Exams.CandidateGroup) =>
+      group.name.trim().length > 0 && group.memberCandidateIds.length > 0
+    );
 
   return Boolean(store.canSave && hasValidCandidates && hasValidGroups);
 });


### PR DESCRIPTION
## DONE
- Fixed the active save blocker in `KBRExamBuilder.vue`.
- Removed the hard requirement that `candidates.length > 0` for saving.
- Candidate rows remain validated when present: if a candidate exists, first and last name are still required.
- Group validation is skipped when there are no candidates, so a template-style exam can be saved without groups.
- Updated helper text to state that candidates are optional for template-style saving.

## NOT DONE
- No repository changes.
- No migration changes.
- No PDF/export/template-copy changes.
- No new dependency.
- No broad refactor.

## CHECKS
- Scope check: exactly one file changed, 15 lines total.
- Diff verified against `main`: branch is 1 commit ahead, 0 behind.
- Local tests were not run in this environment.

## READY FOR NEXT STEP
NOT DONE - run typecheck/CI, then merge if green.