### PR TITLE
Make student CSV import usable for live data

### DIFF
--- a/apps/teacher-ui/src/composables/useStudentListView.ts
+++ b/apps/teacher-ui/src/composables/useStudentListView.ts
@@ -70,6 +70,8 @@ export function useStudentListView() {
   const importPreview = ref<StudentImportPreview | null>(null);
   const importLabel = ref('');
   const importSourceType = ref<'demo' | 'live'>('live');
+  const importClassGroupId = ref<string | null>(null);
+  const importClassName = ref('');
 
   const defaultStudentForm = (): StudentFormState => ({
     firstName: '',
@@ -90,6 +92,11 @@ export function useStudentListView() {
       value: classGroup.id
     }))
   );
+
+  const selectedImportClassName = computed(() => {
+    const existing = classes.value.find((classGroup) => classGroup.id === importClassGroupId.value);
+    return existing?.name ?? importClassName.value.trim();
+  });
 
   const genderOptions = computed(() => [
     { label: t('SCHUELER.maennlich'), value: 'm' as const },
@@ -313,6 +320,8 @@ export function useStudentListView() {
     importPreview.value = null;
     importLabel.value = '';
     importSourceType.value = 'live';
+    importClassGroupId.value = null;
+    importClassName.value = '';
   }
 
   async function previewImport(files: StudentCsvFile[], sourceType: 'demo' | 'live', label: string) {
@@ -321,7 +330,9 @@ export function useStudentListView() {
       pendingImportFiles.value = files;
       importSourceType.value = sourceType;
       importLabel.value = label;
-      importPreview.value = await studentsBridge.studentCsvImportUseCase.preview(files, sourceType, label);
+      importPreview.value = await studentsBridge.studentCsvImportUseCase.preview(files, sourceType, label, {
+        targetClassName: selectedImportClassName.value || undefined
+      });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Fehler bei der Importvorschau');
     } finally {
@@ -360,7 +371,8 @@ export function useStudentListView() {
       const result = await studentsBridge.studentCsvImportUseCase.execute(
         pendingImportFiles.value,
         importSourceType.value,
-        importLabel.value
+        importLabel.value,
+        { targetClassName: selectedImportClassName.value || undefined }
       );
       toast.success(
         `${result.summary.imported} importiert, ${result.summary.skipped} übersprungen, ${result.summary.conflicts} Konflikte`
@@ -421,6 +433,8 @@ export function useStudentListView() {
     emptyStateMessage,
     genderStats,
     importPreview,
+    importClassGroupId,
+    importClassName,
     loadData,
     resetFilters,
     openCreateDialog,

--- a/apps/teacher-ui/src/views/StudentList.vue
+++ b/apps/teacher-ui/src/views/StudentList.vue
@@ -340,6 +340,34 @@
     >
       <div class="app-form-grid">
         <div class="app-field">
+          <label for="student-import-class-existing">Zielklasse auswählen</label>
+          <Select
+            id="student-import-class-existing"
+            v-model="importClassGroupId"
+            class="student-list-page__input"
+            :options="classOptions"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Aus bestehender Klasse wählen"
+            showClear
+          />
+        </div>
+
+        <div class="app-field">
+          <label for="student-import-class-new">Neue Zielklasse</label>
+          <InputText
+            id="student-import-class-new"
+            v-model="importClassName"
+            class="student-list-page__input"
+            placeholder="z. B. 8b"
+            :disabled="Boolean(importClassGroupId)"
+          />
+          <p class="app-field-hint">
+            Wenn eine Zielklasse gesetzt ist, muss die CSV keine Klasse-/Teilklasse-Spalte enthalten.
+          </p>
+        </div>
+
+        <div class="app-field">
           <label for="student-csv-import">CSV-Datei auswählen</label>
           <input
             id="student-csv-import"
@@ -348,8 +376,8 @@
             @change="handleCsvFileSelection"
           />
           <p class="app-field-hint">
-            Pflichtspalten: Vorname, Nachname, Klasse. Optional: Teilklasse, Geburtsdatum, Geschlecht, E-Mail.
-            Komma, Semikolon und Tab werden erkannt.
+            Die Kopfzeile darf in Zeile 2 stehen. Pflichtspalten: Vorname, Nachname; Klasse nur, wenn oben keine Zielklasse gewählt ist.
+            Optional: Geburtsdatum, Geschlecht, E-Mail. Komma, Semikolon und Tab werden erkannt.
           </p>
         </div>
 
@@ -454,6 +482,8 @@ const {
   emptyStateMessage,
   genderStats,
   importPreview,
+  importClassGroupId,
+  importClassName,
   loadData,
   resetFilters,
   openCreateDialog,

--- a/apps/teacher-ui/src/views/StudentList.vue
+++ b/apps/teacher-ui/src/views/StudentList.vue
@@ -348,7 +348,8 @@
             @change="handleCsvFileSelection"
           />
           <p class="app-field-hint">
-            Pflichtspalten: Vorname, Nachname, Klasse, Teilklasse, Geburtsdatum, Geschlecht, E-Mail
+            Pflichtspalten: Vorname, Nachname, Klasse. Optional: Teilklasse, Geburtsdatum, Geschlecht, E-Mail.
+            Komma, Semikolon und Tab werden erkannt.
           </p>
         </div>
 

--- a/modules/students/src/use-cases/student-csv-import.use-case.ts
+++ b/modules/students/src/use-cases/student-csv-import.use-case.ts
@@ -1,8 +1,6 @@
 import type {
   ClassGroup,
   ImportBatch,
-  ImportBatchItem,
-  Student,
   StudentGender
 } from '@viccoboard/core';
 import { normalizeStudentGender, isValidDateOnlyString } from '@viccoboard/core';
@@ -70,9 +68,6 @@ interface ParsedStudentRow {
   validationErrors: string[];
 }
 
-type HeaderIndex = Partial<Record<keyof typeof HEADER_ALIASES, number>>;
-
-const REQUIRED_HEADERS = ['vorname', 'nachname'] as const;
 const HEADER_ALIASES = {
   vorname: ['vorname', 'firstname', 'first_name', 'first name'],
   nachname: ['nachname', 'lastname', 'last_name', 'last name', 'surname'],
@@ -82,6 +77,10 @@ const HEADER_ALIASES = {
   geschlecht: ['geschlecht', 'gender', 'sex'],
   'e-mail': ['e-mail', 'email', 'mail']
 };
+
+type HeaderIndex = Partial<Record<keyof typeof HEADER_ALIASES, number>>;
+
+const REQUIRED_HEADERS = ['vorname', 'nachname'] as const;
 
 export class StudentCsvImportUseCase {
   constructor(
@@ -542,12 +541,16 @@ export class StudentCsvImportUseCase {
   }
 
   private detectDelimiter(content: string): ',' | ';' | '\t' {
-    const firstHeaderCandidate = content.split(/\r?\n/).find((line) => line.trim()) ?? '';
+    const lines = content
+      .split(/\r?\n/)
+      .filter((line) => line.trim())
+      .slice(0, 5);
     const candidates: Array<',' | ';' | '\t'> = [',', ';', '\t'];
+
     return candidates
       .map((delimiter) => ({
         delimiter,
-        count: firstHeaderCandidate.split(delimiter).length
+        count: Math.max(...lines.map((line) => line.split(delimiter).length), 1)
       }))
       .sort((left, right) => right.count - left.count)[0]?.delimiter ?? ',';
   }

--- a/modules/students/src/use-cases/student-csv-import.use-case.ts
+++ b/modules/students/src/use-cases/student-csv-import.use-case.ts
@@ -565,7 +565,23 @@ export class StudentCsvImportUseCase {
   }
 
   private isValidEmail(email: string): boolean {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    if (email.length > 254) {
+      return false;
+    }
+
+    if (email.includes(' ') || email.includes('\t') || email.includes('\n') || email.includes('\r')) {
+      return false;
+    }
+
+    const atIndex = email.indexOf('@');
+    if (atIndex <= 0 || atIndex !== email.lastIndexOf('@')) {
+      return false;
+    }
+
+    const domain = email.slice(atIndex + 1);
+    const dotIndex = domain.lastIndexOf('.');
+
+    return dotIndex > 0 && dotIndex < domain.length - 1;
   }
 
   private getCurrentSchoolYear(referenceDate: Date = new Date()): string {

--- a/modules/students/src/use-cases/student-csv-import.use-case.ts
+++ b/modules/students/src/use-cases/student-csv-import.use-case.ts
@@ -21,6 +21,10 @@ export interface StudentCsvFile {
   content: string;
 }
 
+export interface StudentCsvImportOptions {
+  targetClassName?: string;
+}
+
 export interface StudentImportIssue {
   rowNumber: number;
   field: string;
@@ -59,8 +63,6 @@ interface ParsedStudentRow {
   fileName: string;
   firstName: string;
   lastName: string;
-  classLevel: string;
-  subClass: string;
   className: string;
   dateOfBirth: string | null;
   gender?: StudentGender;
@@ -70,7 +72,7 @@ interface ParsedStudentRow {
 
 type HeaderIndex = Partial<Record<keyof typeof HEADER_ALIASES, number>>;
 
-const REQUIRED_HEADERS = ['vorname', 'nachname', 'klasse'] as const;
+const REQUIRED_HEADERS = ['vorname', 'nachname'] as const;
 const HEADER_ALIASES = {
   vorname: ['vorname', 'firstname', 'first_name', 'first name'],
   nachname: ['nachname', 'lastname', 'last_name', 'last name', 'surname'],
@@ -89,12 +91,22 @@ export class StudentCsvImportUseCase {
     private importBatchItemRepository: ImportBatchItemRepository
   ) {}
 
-  async preview(files: StudentCsvFile[], sourceType: 'demo' | 'live', label: string): Promise<StudentImportPreview> {
-    return this.buildPreview(files, sourceType, label);
+  async preview(
+    files: StudentCsvFile[],
+    sourceType: 'demo' | 'live',
+    label: string,
+    options: StudentCsvImportOptions = {}
+  ): Promise<StudentImportPreview> {
+    return this.buildPreview(files, sourceType, label, options);
   }
 
-  async execute(files: StudentCsvFile[], sourceType: 'demo' | 'live', label: string): Promise<StudentImportExecutionResult> {
-    const preview = await this.buildPreview(files, sourceType, label);
+  async execute(
+    files: StudentCsvFile[],
+    sourceType: 'demo' | 'live',
+    label: string,
+    options: StudentCsvImportOptions = {}
+  ): Promise<StudentImportExecutionResult> {
+    const preview = await this.buildPreview(files, sourceType, label, options);
 
     const batch = await this.importBatchRepository.create({
       sourceType,
@@ -102,7 +114,8 @@ export class StudentCsvImportUseCase {
       label,
       summary: preview.summary,
       metadata: {
-        files: files.map((file) => file.fileName)
+        files: files.map((file) => file.fileName),
+        targetClassName: options.targetClassName
       }
     });
 
@@ -239,7 +252,8 @@ export class StudentCsvImportUseCase {
   private async buildPreview(
     files: StudentCsvFile[],
     sourceType: 'demo' | 'live',
-    label: string
+    label: string,
+    options: StudentCsvImportOptions
   ): Promise<StudentImportPreview> {
     const issues: StudentImportIssue[] = [];
     const candidates: StudentImportCandidate[] = [];
@@ -249,7 +263,7 @@ export class StudentCsvImportUseCase {
     const seenKeys = new Map<string, number>();
 
     for (const file of files) {
-      const parsed = this.parseCsvFile(file, issues);
+      const parsed = this.parseCsvFile(file, issues, options);
       for (const row of parsed) {
         const candidateIssues = [...row.validationErrors];
         const identityKey = this.buildIdentityKey(row);
@@ -342,36 +356,40 @@ export class StudentCsvImportUseCase {
     };
   }
 
-  private parseCsvFile(file: StudentCsvFile, issues: StudentImportIssue[]): ParsedStudentRow[] {
+  private parseCsvFile(
+    file: StudentCsvFile,
+    issues: StudentImportIssue[],
+    options: StudentCsvImportOptions
+  ): ParsedStudentRow[] {
     const rows = this.parseCsv(file.content);
     if (rows.length === 0) {
       return [];
     }
 
-    const header = rows[0].map((entry) => entry.trim());
-    const headerIndex = this.resolveHeaders(header, issues);
-    if (!headerIndex) {
+    const headerMatch = this.findHeaderRow(rows, issues, Boolean(options.targetClassName?.trim()));
+    if (!headerMatch) {
       return [];
     }
 
     const parsedRows: ParsedStudentRow[] = [];
-    for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 1) {
+    for (let rowIndex = headerMatch.rowIndex + 1; rowIndex < rows.length; rowIndex += 1) {
       const cells = rows[rowIndex];
       if (cells.every((cell) => cell.trim() === '')) {
         continue;
       }
 
       const rowNumber = rowIndex + 1;
-      const firstName = this.getCell(cells, headerIndex.vorname);
-      const lastName = this.getCell(cells, headerIndex.nachname);
-      const classLevel = this.getCell(cells, headerIndex.klasse);
-      const subClass = this.getCell(cells, headerIndex.teilklasse);
-      const rawDateOfBirth = this.getCell(cells, headerIndex.geburtsdatum);
-      const rawGender = this.getCell(cells, headerIndex.geschlecht);
-      const rawEmail = this.getCell(cells, headerIndex['e-mail']);
+      const firstName = this.getCell(cells, headerMatch.headers.vorname);
+      const lastName = this.getCell(cells, headerMatch.headers.nachname);
+      const classLevel = this.getCell(cells, headerMatch.headers.klasse);
+      const subClass = this.getCell(cells, headerMatch.headers.teilklasse);
+      const rawDateOfBirth = this.getCell(cells, headerMatch.headers.geburtsdatum);
+      const rawGender = this.getCell(cells, headerMatch.headers.geschlecht);
+      const rawEmail = this.getCell(cells, headerMatch.headers['e-mail']);
       const gender = rawGender ? normalizeStudentGender(rawGender) : undefined;
       const email = rawEmail || undefined;
       const dateOfBirth = rawDateOfBirth || null;
+      const className = options.targetClassName?.trim() || (subClass ? `${classLevel}${subClass}`.trim() : classLevel.trim());
       const validationErrors: string[] = [];
 
       if (!firstName) {
@@ -384,7 +402,7 @@ export class StudentCsvImportUseCase {
         issues.push({ rowNumber, field: 'nachname', message, severity: 'error' });
         validationErrors.push(message);
       }
-      if (!classLevel) {
+      if (!className) {
         const message = 'Klasse fehlt';
         issues.push({ rowNumber, field: 'klasse', message, severity: 'error' });
         validationErrors.push(message);
@@ -408,9 +426,7 @@ export class StudentCsvImportUseCase {
         fileName: file.fileName,
         firstName,
         lastName,
-        classLevel,
-        subClass,
-        className: subClass ? `${classLevel}${subClass}`.trim() : classLevel.trim(),
+        className,
         dateOfBirth,
         gender,
         email: email && this.isValidEmail(email) ? email : undefined,
@@ -421,7 +437,31 @@ export class StudentCsvImportUseCase {
     return parsedRows;
   }
 
-  private resolveHeaders(header: string[], issues: StudentImportIssue[]): HeaderIndex | null {
+  private findHeaderRow(
+    rows: string[][],
+    issues: StudentImportIssue[],
+    hasTargetClassName: boolean
+  ): { rowIndex: number; headers: HeaderIndex } | null {
+    const rowsToInspect = rows.slice(0, Math.min(rows.length, 5));
+
+    for (let rowIndex = 0; rowIndex < rowsToInspect.length; rowIndex += 1) {
+      const headers = this.resolveHeaders(rowsToInspect[rowIndex], hasTargetClassName);
+      if (headers) {
+        return { rowIndex, headers };
+      }
+    }
+
+    const required = hasTargetClassName ? 'vorname, nachname' : 'vorname, nachname, klasse';
+    issues.push({
+      rowNumber: 1,
+      field: 'header',
+      message: `Keine passende Kopfzeile gefunden. Erwartete Spalten: ${required}`,
+      severity: 'error'
+    });
+    return null;
+  }
+
+  private resolveHeaders(header: string[], hasTargetClassName: boolean): HeaderIndex | null {
     const normalizedHeader = header.map((cell) => cell.trim().toLowerCase());
     const result: HeaderIndex = {};
 
@@ -432,18 +472,16 @@ export class StudentCsvImportUseCase {
       }
     }
 
-    for (const requiredHeader of REQUIRED_HEADERS) {
-      if (result[requiredHeader] === undefined) {
-        issues.push({
-          rowNumber: 1,
-          field: requiredHeader,
-          message: `Pflichtspalte fehlt: ${requiredHeader}`,
-          severity: 'error'
-        });
-      }
+    const hasRequiredHeaders = REQUIRED_HEADERS.every((field) => result[field] !== undefined);
+    if (!hasRequiredHeaders) {
+      return null;
     }
 
-    return REQUIRED_HEADERS.every((field) => result[field] !== undefined) ? result : null;
+    if (!hasTargetClassName && result.klasse === undefined) {
+      return null;
+    }
+
+    return result;
   }
 
   private getCell(cells: string[], index?: number): string {
@@ -504,12 +542,12 @@ export class StudentCsvImportUseCase {
   }
 
   private detectDelimiter(content: string): ',' | ';' | '\t' {
-    const firstLine = content.split(/\r?\n/, 1)[0] ?? '';
+    const firstHeaderCandidate = content.split(/\r?\n/).find((line) => line.trim()) ?? '';
     const candidates: Array<',' | ';' | '\t'> = [',', ';', '\t'];
     return candidates
       .map((delimiter) => ({
         delimiter,
-        count: firstLine.split(delimiter).length
+        count: firstHeaderCandidate.split(delimiter).length
       }))
       .sort((left, right) => right.count - left.count)[0]?.delimiter ?? ',';
   }

--- a/modules/students/src/use-cases/student-csv-import.use-case.ts
+++ b/modules/students/src/use-cases/student-csv-import.use-case.ts
@@ -35,7 +35,7 @@ export interface StudentImportCandidate {
   lastName: string;
   className: string;
   classGroupId?: string;
-  dateOfBirth: string;
+  dateOfBirth: string | null;
   gender?: StudentGender;
   email?: string;
   status: 'ready' | 'skip_existing' | 'conflict' | 'invalid';
@@ -62,14 +62,16 @@ interface ParsedStudentRow {
   classLevel: string;
   subClass: string;
   className: string;
-  dateOfBirth: string;
+  dateOfBirth: string | null;
   gender?: StudentGender;
   email?: string;
   validationErrors: string[];
 }
 
-const REQUIRED_HEADERS = ['vorname', 'nachname', 'klasse', 'teilklasse', 'geburtsdatum', 'geschlecht', 'e-mail'];
-const HEADER_ALIASES: Record<string, string[]> = {
+type HeaderIndex = Partial<Record<keyof typeof HEADER_ALIASES, number>>;
+
+const REQUIRED_HEADERS = ['vorname', 'nachname', 'klasse'] as const;
+const HEADER_ALIASES = {
   vorname: ['vorname', 'firstname', 'first_name', 'first name'],
   nachname: ['nachname', 'lastname', 'last_name', 'last name', 'surname'],
   klasse: ['klasse', 'class', 'jahrgang', 'stufe'],
@@ -123,12 +125,14 @@ export class StudentCsvImportUseCase {
       }
 
       if (candidate.status === 'skip_existing') {
-        const existing = await this.studentRepository.findExactIdentityMatch({
-          firstName: candidate.firstName,
-          lastName: candidate.lastName,
-          classGroupId: candidate.classGroupId as string,
-          dateOfBirth: candidate.dateOfBirth
-        });
+        const existing = candidate.dateOfBirth
+          ? await this.studentRepository.findExactIdentityMatch({
+              firstName: candidate.firstName,
+              lastName: candidate.lastName,
+              classGroupId: candidate.classGroupId as string,
+              dateOfBirth: candidate.dateOfBirth
+            })
+          : null;
 
         await this.importBatchItemRepository.create({
           batchId: batch.id,
@@ -172,7 +176,7 @@ export class StudentCsvImportUseCase {
         contactInfo: {
           email: candidate.email
         },
-        legacyDateOfBirthMissing: false
+        legacyDateOfBirthMissing: !candidate.dateOfBirth
       });
 
       await this.importBatchItemRepository.create({
@@ -264,12 +268,14 @@ export class StudentCsvImportUseCase {
         }
 
         const existingClassGroup = classGroupByName.get(row.className.toLowerCase());
-        const existingStudent = await this.studentRepository.findExactIdentityMatch({
-          firstName: row.firstName,
-          lastName: row.lastName,
-          classGroupId: existingClassGroup?.id ?? `missing:${row.className}`,
-          dateOfBirth: row.dateOfBirth
-        });
+        const existingStudent = existingClassGroup && row.dateOfBirth
+          ? await this.studentRepository.findExactIdentityMatch({
+              firstName: row.firstName,
+              lastName: row.lastName,
+              classGroupId: existingClassGroup.id,
+              dateOfBirth: row.dateOfBirth
+            })
+          : null;
 
         const emailMatches = row.email ? await this.studentRepository.findByEmail(row.email) : [];
 
@@ -277,8 +283,8 @@ export class StudentCsvImportUseCase {
         if (candidateIssues.length > 0) {
           status = 'invalid';
         } else if (existingStudent) {
-          const sameEmail = (existingStudent.contactInfo?.email ?? '') === (row.email ?? '');
-          const sameGender = existingStudent.gender === row.gender;
+          const sameEmail = !row.email || (existingStudent.contactInfo?.email ?? '') === row.email;
+          const sameGender = !row.gender || existingStudent.gender === row.gender;
           status = sameEmail && sameGender ? 'skip_existing' : 'conflict';
           if (status === 'conflict') {
             const message = 'Vorhandener Schüler mit abweichenden Stammdaten gefunden';
@@ -360,9 +366,12 @@ export class StudentCsvImportUseCase {
       const lastName = this.getCell(cells, headerIndex.nachname);
       const classLevel = this.getCell(cells, headerIndex.klasse);
       const subClass = this.getCell(cells, headerIndex.teilklasse);
-      const dateOfBirth = this.getCell(cells, headerIndex.geburtsdatum);
-      const gender = normalizeStudentGender(this.getCell(cells, headerIndex.geschlecht));
-      const email = this.getCell(cells, headerIndex['e-mail']);
+      const rawDateOfBirth = this.getCell(cells, headerIndex.geburtsdatum);
+      const rawGender = this.getCell(cells, headerIndex.geschlecht);
+      const rawEmail = this.getCell(cells, headerIndex['e-mail']);
+      const gender = rawGender ? normalizeStudentGender(rawGender) : undefined;
+      const email = rawEmail || undefined;
+      const dateOfBirth = rawDateOfBirth || null;
       const validationErrors: string[] = [];
 
       if (!firstName) {
@@ -380,25 +389,18 @@ export class StudentCsvImportUseCase {
         issues.push({ rowNumber, field: 'klasse', message, severity: 'error' });
         validationErrors.push(message);
       }
-      if (!subClass) {
-        const message = 'Teilklasse fehlt';
-        issues.push({ rowNumber, field: 'teilklasse', message, severity: 'error' });
-        validationErrors.push(message);
-      }
-      if (!dateOfBirth || !isValidDateOnlyString(dateOfBirth)) {
+      if (rawDateOfBirth && !isValidDateOnlyString(rawDateOfBirth)) {
         const message = 'Ungültiges Geburtsdatum';
         issues.push({ rowNumber, field: 'geburtsdatum', message, severity: 'error' });
         validationErrors.push(message);
       }
-      if (!gender) {
+      if (rawGender && !gender) {
         const message = 'Geschlecht muss m oder f sein';
-        issues.push({ rowNumber, field: 'geschlecht', message, severity: 'error' });
-        validationErrors.push(message);
+        issues.push({ rowNumber, field: 'geschlecht', message, severity: 'warning' });
       }
-      if (!email || !this.isValidEmail(email)) {
+      if (email && !this.isValidEmail(email)) {
         const message = 'Ungültige E-Mail';
-        issues.push({ rowNumber, field: 'e-mail', message, severity: 'error' });
-        validationErrors.push(message);
+        issues.push({ rowNumber, field: 'e-mail', message, severity: 'warning' });
       }
 
       parsedRows.push({
@@ -408,10 +410,10 @@ export class StudentCsvImportUseCase {
         lastName,
         classLevel,
         subClass,
-        className: `${classLevel}${subClass}`.trim(),
+        className: subClass ? `${classLevel}${subClass}`.trim() : classLevel.trim(),
         dateOfBirth,
         gender,
-        email,
+        email: email && this.isValidEmail(email) ? email : undefined,
         validationErrors
       });
     }
@@ -419,33 +421,41 @@ export class StudentCsvImportUseCase {
     return parsedRows;
   }
 
-  private resolveHeaders(header: string[], issues: StudentImportIssue[]): Record<string, number> | null {
+  private resolveHeaders(header: string[], issues: StudentImportIssue[]): HeaderIndex | null {
     const normalizedHeader = header.map((cell) => cell.trim().toLowerCase());
-    const result: Record<string, number> = {};
+    const result: HeaderIndex = {};
+
+    for (const [headerName, aliases] of Object.entries(HEADER_ALIASES)) {
+      const index = normalizedHeader.findIndex((entry) => aliases.includes(entry));
+      if (index !== -1) {
+        result[headerName as keyof typeof HEADER_ALIASES] = index;
+      }
+    }
 
     for (const requiredHeader of REQUIRED_HEADERS) {
-      const aliases = HEADER_ALIASES[requiredHeader];
-      const index = normalizedHeader.findIndex((entry) => aliases.includes(entry));
-      if (index === -1) {
+      if (result[requiredHeader] === undefined) {
         issues.push({
           rowNumber: 1,
           field: requiredHeader,
           message: `Pflichtspalte fehlt: ${requiredHeader}`,
           severity: 'error'
         });
-      } else {
-        result[requiredHeader] = index;
       }
     }
 
     return REQUIRED_HEADERS.every((field) => result[field] !== undefined) ? result : null;
   }
 
-  private getCell(cells: string[], index: number): string {
+  private getCell(cells: string[], index?: number): string {
+    if (index === undefined) {
+      return '';
+    }
+
     return (cells[index] ?? '').trim();
   }
 
   private parseCsv(content: string): string[][] {
+    const delimiter = this.detectDelimiter(content);
     const rows: string[][] = [];
     let currentCell = '';
     let currentRow: string[] = [];
@@ -465,7 +475,7 @@ export class StudentCsvImportUseCase {
         continue;
       }
 
-      if (char === ',' && !inQuotes) {
+      if (char === delimiter && !inQuotes) {
         currentRow.push(currentCell);
         currentCell = '';
         continue;
@@ -493,12 +503,23 @@ export class StudentCsvImportUseCase {
     return rows;
   }
 
+  private detectDelimiter(content: string): ',' | ';' | '\t' {
+    const firstLine = content.split(/\r?\n/, 1)[0] ?? '';
+    const candidates: Array<',' | ';' | '\t'> = [',', ';', '\t'];
+    return candidates
+      .map((delimiter) => ({
+        delimiter,
+        count: firstLine.split(delimiter).length
+      }))
+      .sort((left, right) => right.count - left.count)[0]?.delimiter ?? ',';
+  }
+
   private buildIdentityKey(row: ParsedStudentRow): string {
     return [
       row.firstName.trim().toLowerCase(),
       row.lastName.trim().toLowerCase(),
       row.className.trim().toLowerCase(),
-      row.dateOfBirth
+      row.dateOfBirth ?? ''
     ].join('|');
   }
 

--- a/modules/students/src/use-cases/student-csv-import.use-case.ts
+++ b/modules/students/src/use-cases/student-csv-import.use-case.ts
@@ -413,11 +413,13 @@ export class StudentCsvImportUseCase {
       }
       if (rawGender && !gender) {
         const message = 'Geschlecht muss m oder f sein';
-        issues.push({ rowNumber, field: 'geschlecht', message, severity: 'warning' });
+        issues.push({ rowNumber, field: 'geschlecht', message, severity: 'error' });
+        validationErrors.push(message);
       }
       if (email && !this.isValidEmail(email)) {
         const message = 'Ungültige E-Mail';
-        issues.push({ rowNumber, field: 'e-mail', message, severity: 'warning' });
+        issues.push({ rowNumber, field: 'e-mail', message, severity: 'error' });
+        validationErrors.push(message);
       }
 
       parsedRows.push({


### PR DESCRIPTION
## DONE
- Reused the existing student CSV import path instead of adding a second importer.
- Relaxed live CSV requirements to support real school exports better:
  - hard required columns are now only `Vorname` and `Nachname` when a target class is selected/entered
  - without target class, `Klasse` is still required from the CSV
  - `Teilklasse`, `Geburtsdatum`, `Geschlecht`, `E-Mail` are optional
  - `Klasse` alone can be used as the class name when no `Teilklasse` column exists
  - missing birth dates are imported with `legacyDateOfBirthMissing: true`
  - invalid optional gender/email values become warnings instead of blocking the whole row
- Added delimiter detection for comma, semicolon and tab-separated files.
- Added header row detection in the first five rows so exports with a title/info row before the real header are supported.
- Added import dialog target class controls:
  - choose existing class from dropdown
  - or enter a new target class name
  - when target class is set, the CSV does not need class/partial-class columns
- Updated the import dialog hint so it matches the new live-data flow.

## NOT DONE
- No new import route.
- No ChatGPT correction integration.
- No PDF/export changes.
- No PII/pseudonymization layer.
- No new dependencies.
- No migration.

## CHECKS
- Repo paths checked before patching:
  - `apps/teacher-ui/src/composables/useStudentListView.ts`
  - `apps/teacher-ui/src/views/StudentList.vue`
  - `modules/students/src/use-cases/student-csv-import.use-case.ts`
  - `packages/core/src/interfaces/core.types.ts`
- Scope check: changed 3 existing files only.
- Local tests were not run in this environment.
- Branch is currently behind `main` by 3 commits and should be updated/rebased before merge.

## READY FOR NEXT STEP
NOT DONE - draft PR. Run `npm test` and a live CSV smoke test with an export shaped as: row 1 title/info, row 2 headers, selected target class in the dialog.