### PR TITLE
Add live data backup guardrails

### DIFF
--- a/apps/teacher-ui/src/router/index.ts
+++ b/apps/teacher-ui/src/router/index.ts
@@ -35,6 +35,12 @@ const routes: RouteRecordRaw[] = [
     meta: { title: 'Einstellungen', parent: '/' }
   },
   {
+    path: '/settings/backups',
+    name: 'backup-restore',
+    component: () => import('../views/BackupRestoreView.vue'),
+    meta: { title: 'Backups & Wiederherstellung', parent: '/settings' }
+  },
+  {
     path: '/settings/catalogs',
     name: 'catalog-management',
     component: () => import('../views/CatalogManagement.vue'),

--- a/apps/teacher-ui/src/services/live-data-backup.service.ts
+++ b/apps/teacher-ui/src/services/live-data-backup.service.ts
@@ -16,7 +16,16 @@ export interface LiveDataBackupFile {
 export interface LiveDataRestoreResult {
   importedStores: number
   skippedStores: string[]
-  importedRecords: number
+  insertedRecords: number
+  mergedRecords: number
+  unchangedRecords: number
+  conflictRecords: number
+}
+
+interface MergeResult {
+  value: unknown
+  changed: boolean
+  conflict: boolean
 }
 
 export async function createLiveDataBackup(): Promise<LiveDataBackupFile> {
@@ -49,8 +58,11 @@ export async function restoreLiveDataBackup(backup: LiveDataBackupFile): Promise
   assertBackupFile(backup)
 
   const db = getStorage().getDatabase()
+  let insertedRecords = 0
+  let mergedRecords = 0
+  let unchangedRecords = 0
+  let conflictRecords = 0
   let importedStores = 0
-  let importedRecords = 0
   const skippedStores: string[] = []
 
   for (const storeBackup of backup.stores) {
@@ -60,13 +72,20 @@ export async function restoreLiveDataBackup(backup: LiveDataBackupFile): Promise
     }
 
     importedStores += 1
-    importedRecords += await putRecords(db, storeBackup.name, storeBackup.records)
+    const result = await restoreChangedRecords(db, storeBackup.name, storeBackup.records)
+    insertedRecords += result.insertedRecords
+    mergedRecords += result.mergedRecords
+    unchangedRecords += result.unchangedRecords
+    conflictRecords += result.conflictRecords
   }
 
   return {
     importedStores,
     skippedStores,
-    importedRecords
+    insertedRecords,
+    mergedRecords,
+    unchangedRecords,
+    conflictRecords
   }
 }
 
@@ -102,27 +121,186 @@ function readAllRecords(db: IDBDatabase, storeName: string): Promise<Array<Recor
   })
 }
 
-function putRecords(
+function restoreChangedRecords(
   db: IDBDatabase,
   storeName: string,
   records: Array<Record<string, unknown>>
-): Promise<number> {
+): Promise<{
+  insertedRecords: number
+  mergedRecords: number
+  unchangedRecords: number
+  conflictRecords: number
+}> {
   if (records.length === 0) {
-    return Promise.resolve(0)
+    return Promise.resolve({
+      insertedRecords: 0,
+      mergedRecords: 0,
+      unchangedRecords: 0,
+      conflictRecords: 0
+    })
   }
 
   return new Promise((resolve, reject) => {
     const tx = db.transaction(storeName, 'readwrite')
     const store = tx.objectStore(storeName)
-    let queued = 0
+    let insertedRecords = 0
+    let mergedRecords = 0
+    let unchangedRecords = 0
+    let conflictRecords = 0
 
-    for (const record of records) {
-      store.put(record)
-      queued += 1
-    }
-
-    tx.oncomplete = () => resolve(queued)
+    tx.oncomplete = () => resolve({ insertedRecords, mergedRecords, unchangedRecords, conflictRecords })
     tx.onerror = () => reject(tx.error)
     tx.onabort = () => reject(tx.error ?? new Error('Die Wiederherstellung wurde abgebrochen.'))
+
+    for (const backupRecord of records) {
+      const id = backupRecord.id
+      if (typeof id !== 'string') {
+        tx.abort()
+        reject(new Error(`Backup-Datensatz in ${storeName} hat keine gültige ID.`))
+        return
+      }
+
+      const getRequest = store.get(id)
+      getRequest.onsuccess = () => {
+        const currentRecord = getRequest.result as Record<string, unknown> | undefined
+        if (!currentRecord) {
+          store.put(backupRecord)
+          insertedRecords += 1
+          return
+        }
+
+        const merge = mergeValue(currentRecord, backupRecord)
+        if (merge.conflict) {
+          conflictRecords += 1
+          return
+        }
+
+        if (!merge.changed) {
+          unchangedRecords += 1
+          return
+        }
+
+        store.put(merge.value as Record<string, unknown>)
+        mergedRecords += 1
+      }
+      getRequest.onerror = () => reject(getRequest.error)
+    }
   })
+}
+
+function mergeValue(current: unknown, incoming: unknown): MergeResult {
+  if (stableStringify(current) === stableStringify(incoming)) {
+    return { value: current, changed: false, conflict: false }
+  }
+
+  if (current === undefined || current === null || current === '') {
+    return { value: incoming, changed: true, conflict: false }
+  }
+
+  if (incoming === undefined || incoming === null || incoming === '') {
+    return { value: current, changed: false, conflict: false }
+  }
+
+  if (Array.isArray(current) && Array.isArray(incoming)) {
+    return mergeArray(current, incoming)
+  }
+
+  if (isPlainRecord(current) && isPlainRecord(incoming)) {
+    return mergeRecord(current, incoming)
+  }
+
+  return { value: current, changed: false, conflict: true }
+}
+
+function mergeRecord(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): MergeResult {
+  const merged: Record<string, unknown> = { ...current }
+  let changed = false
+  let conflict = false
+
+  for (const key of Object.keys(incoming)) {
+    const result = mergeValue(current[key], incoming[key])
+    if (result.conflict) {
+      conflict = true
+      continue
+    }
+    if (result.changed) {
+      merged[key] = result.value
+      changed = true
+    }
+  }
+
+  return { value: merged, changed, conflict }
+}
+
+function mergeArray(current: unknown[], incoming: unknown[]): MergeResult {
+  if (canMergeArrayById(current) && canMergeArrayById(incoming)) {
+    return mergeArrayById(current, incoming)
+  }
+
+  const merged = [...current]
+  let changed = false
+
+  for (const incomingItem of incoming) {
+    if (!merged.some((currentItem) => stableStringify(currentItem) === stableStringify(incomingItem))) {
+      merged.push(incomingItem)
+      changed = true
+    }
+  }
+
+  return { value: merged, changed, conflict: false }
+}
+
+function mergeArrayById(current: Array<Record<string, unknown>>, incoming: Array<Record<string, unknown>>): MergeResult {
+  const merged = [...current]
+  let changed = false
+  let conflict = false
+
+  for (const incomingItem of incoming) {
+    const id = incomingItem.id
+    const index = merged.findIndex((currentItem) => currentItem.id === id)
+
+    if (index === -1) {
+      merged.push(incomingItem)
+      changed = true
+      continue
+    }
+
+    const result = mergeRecord(merged[index], incomingItem)
+    if (result.conflict) {
+      conflict = true
+      continue
+    }
+    if (result.changed) {
+      merged[index] = result.value as Record<string, unknown>
+      changed = true
+    }
+  }
+
+  return { value: merged, changed, conflict }
+}
+
+function canMergeArrayById(items: unknown[]): items is Array<Record<string, unknown>> {
+  return items.every((item) => isPlainRecord(item) && typeof item.id === 'string')
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+
+  if (isPlainRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`
+  }
+
+  return JSON.stringify(value)
 }

--- a/apps/teacher-ui/src/services/live-data-backup.service.ts
+++ b/apps/teacher-ui/src/services/live-data-backup.service.ts
@@ -1,0 +1,128 @@
+import { getStorage, VICCOBOARD_DATABASE_NAME } from './storage.service'
+
+export interface LiveDataBackupStore {
+  name: string
+  records: Array<Record<string, unknown>>
+}
+
+export interface LiveDataBackupFile {
+  format: 'viccoboard-live-data-backup'
+  formatVersion: 1
+  databaseName: string
+  exportedAt: string
+  stores: LiveDataBackupStore[]
+}
+
+export interface LiveDataRestoreResult {
+  importedStores: number
+  skippedStores: string[]
+  importedRecords: number
+}
+
+export async function createLiveDataBackup(): Promise<LiveDataBackupFile> {
+  const db = getStorage().getDatabase()
+  const stores = Array.from(db.objectStoreNames).sort()
+  const backupStores: LiveDataBackupStore[] = []
+
+  for (const storeName of stores) {
+    backupStores.push({
+      name: storeName,
+      records: await readAllRecords(db, storeName)
+    })
+  }
+
+  return {
+    format: 'viccoboard-live-data-backup',
+    formatVersion: 1,
+    databaseName: VICCOBOARD_DATABASE_NAME,
+    exportedAt: new Date().toISOString(),
+    stores: backupStores
+  }
+}
+
+export function buildBackupFileName(referenceDate = new Date()): string {
+  const stamp = referenceDate.toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  return `viccoboard-backup-${stamp}.json`
+}
+
+export async function restoreLiveDataBackup(backup: LiveDataBackupFile): Promise<LiveDataRestoreResult> {
+  assertBackupFile(backup)
+
+  const db = getStorage().getDatabase()
+  let importedStores = 0
+  let importedRecords = 0
+  const skippedStores: string[] = []
+
+  for (const storeBackup of backup.stores) {
+    if (!db.objectStoreNames.contains(storeBackup.name)) {
+      skippedStores.push(storeBackup.name)
+      continue
+    }
+
+    importedStores += 1
+    importedRecords += await putRecords(db, storeBackup.name, storeBackup.records)
+  }
+
+  return {
+    importedStores,
+    skippedStores,
+    importedRecords
+  }
+}
+
+export function parseLiveDataBackup(content: string): LiveDataBackupFile {
+  const parsed = JSON.parse(content) as unknown
+  assertBackupFile(parsed)
+  return parsed
+}
+
+function assertBackupFile(value: unknown): asserts value is LiveDataBackupFile {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Die Backup-Datei ist ungültig.')
+  }
+
+  const backup = value as Partial<LiveDataBackupFile>
+  if (backup.format !== 'viccoboard-live-data-backup' || backup.formatVersion !== 1) {
+    throw new Error('Die Backup-Datei hat kein unterstütztes ViccoBoard-Format.')
+  }
+
+  if (!Array.isArray(backup.stores)) {
+    throw new Error('Die Backup-Datei enthält keine Store-Daten.')
+  }
+}
+
+function readAllRecords(db: IDBDatabase, storeName: string): Promise<Array<Record<string, unknown>>> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly')
+    const request = tx.objectStore(storeName).getAll()
+
+    request.onsuccess = () => resolve(request.result as Array<Record<string, unknown>>)
+    request.onerror = () => reject(request.error)
+    tx.onerror = () => reject(tx.error)
+  })
+}
+
+function putRecords(
+  db: IDBDatabase,
+  storeName: string,
+  records: Array<Record<string, unknown>>
+): Promise<number> {
+  if (records.length === 0) {
+    return Promise.resolve(0)
+  }
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite')
+    const store = tx.objectStore(storeName)
+    let queued = 0
+
+    for (const record of records) {
+      store.put(record)
+      queued += 1
+    }
+
+    tx.oncomplete = () => resolve(queued)
+    tx.onerror = () => reject(tx.error)
+    tx.onabort = () => reject(tx.error ?? new Error('Die Wiederherstellung wurde abgebrochen.'))
+  })
+}

--- a/apps/teacher-ui/src/services/storage.service.ts
+++ b/apps/teacher-ui/src/services/storage.service.ts
@@ -1,11 +1,3 @@
-/**
- * Storage Service
- * Initializes and manages @viccoboard/storage for the UI
- * This is the ONLY place where storage should be initialized in the app
- * 
- * ARCHITECTURE: Provides shared storage instance to all composables/bridges
- */
-
 import {
   IndexedDBStorage,
   IndexedDBInitialSchemaMigration,
@@ -30,24 +22,21 @@ import {
 } from '@viccoboard/storage/browser';
 import type { StorageAdapter } from '@viccoboard/storage/browser';
 
+export const VICCOBOARD_DATABASE_NAME = 'viccoboard';
+
 let storageInstance: IndexedDBStorage | null = null;
 let storageInitialized = false;
 
-/**
- * Initialize storage (should be called in main.ts or App.vue setup)
- */
 export async function initializeStorage(): Promise<StorageAdapter> {
   if (storageInitialized && storageInstance) {
     return storageInstance.getAdapter();
   }
 
-  // Create storage instance
   const storage = new IndexedDBStorage({
-    databaseName: 'viccoboard',
+    databaseName: VICCOBOARD_DATABASE_NAME,
     version: 1
   });
 
-  // Register IndexedDB migrations (keeps schema aligned with package migrations)
   storage.registerMigration(new IndexedDBInitialSchemaMigration());
   storage.registerMigration(new IndexedDBGradingSchemaMigration());
   storage.registerMigration(new IndexedDBShuttleRunSchemaMigration());
@@ -68,8 +57,6 @@ export async function initializeStorage(): Promise<StorageAdapter> {
   storage.registerMigration(new IndexedDBStudentImportBatchesMigration());
   storage.registerMigration(new IndexedDBLessonScheduleFieldsMigration());
 
-  // Initialize with empty password (no encryption yet)
-  // TODO: Implement proper encryption/password in Phase X
   await storage.initialize('');
 
   storageInstance = storage;
@@ -78,9 +65,6 @@ export async function initializeStorage(): Promise<StorageAdapter> {
   return storage.getAdapter();
 }
 
-/**
- * Get initialized storage instance
- */
 export function getStorage(): IndexedDBStorage {
   if (!storageInstance) {
     throw new Error(
@@ -90,16 +74,10 @@ export function getStorage(): IndexedDBStorage {
   return storageInstance;
 }
 
-/**
- * Get storage adapter (for repositories)
- */
 export function getStorageAdapter(): StorageAdapter {
   return getStorage().getAdapter();
 }
 
-/**
- * Close storage (for cleanup)
- */
 export async function closeStorage(): Promise<void> {
   if (storageInstance) {
     await storageInstance.close();
@@ -108,9 +86,6 @@ export async function closeStorage(): Promise<void> {
   }
 }
 
-/**
- * Check if storage is initialized
- */
 export function isStorageInitialized(): boolean {
   return storageInitialized && storageInstance !== null;
 }

--- a/apps/teacher-ui/src/settings-sections.ts
+++ b/apps/teacher-ui/src/settings-sections.ts
@@ -14,9 +14,9 @@ export const settingsCards: SettingsCard[] = [
   },
   {
     title: 'Backups & Wiederherstellung',
-    description: 'Export, Import und Backup-Status für die iPad-Safari-Realität.',
-    status: 'in Aufbau',
-    to: null
+    description: 'Export, Import und Backup-Status für lokale Live-Daten.',
+    status: 'verfügbar',
+    to: '/settings/backups'
   },
   {
     title: 'Sprache & Einrichtung',

--- a/apps/teacher-ui/src/views/BackupRestoreView.vue
+++ b/apps/teacher-ui/src/views/BackupRestoreView.vue
@@ -29,7 +29,10 @@
 
       <article class="backup-card">
         <h2>Backup wiederherstellen</h2>
-        <p>Importiert eine ViccoBoard-Backup-Datei. Es werden keine Stores geleert.</p>
+        <p>
+          Importiert eine ViccoBoard-Backup-Datei differenziell. Neue Datensätze werden ergänzt,
+          nicht geänderte Datensätze bleiben unberührt.
+        </p>
         <input
           type="file"
           accept="application/json,.json"
@@ -104,10 +107,16 @@ async function handleRestoreFile(event: Event): Promise<void> {
 
     const backup = parseLiveDataBackup(await file.text())
     const result = await restoreLiveDataBackup(backup)
-    statusMessage.value = `${result.importedRecords} Datensätze aus ${result.importedStores} Bereichen importiert.`
+    statusMessage.value = [
+      `${result.insertedRecords} neu`,
+      `${result.mergedRecords} ergänzt`,
+      `${result.unchangedRecords} unverändert`,
+      `${result.conflictRecords} Konflikte`,
+      `${result.importedStores} Bereiche geprüft`
+    ].join(' · ')
 
     if (result.skippedStores.length > 0) {
-      statusMessage.value += ` Übersprungen: ${result.skippedStores.join(', ')}.`
+      statusMessage.value += ` · Übersprungen: ${result.skippedStores.join(', ')}`
     }
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Backup konnte nicht importiert werden.'

--- a/apps/teacher-ui/src/views/BackupRestoreView.vue
+++ b/apps/teacher-ui/src/views/BackupRestoreView.vue
@@ -1,0 +1,205 @@
+<template>
+  <section class="backup-page">
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">Live-Daten</p>
+        <h1>Backups & Wiederherstellung</h1>
+        <p class="subtitle">
+          Erstelle vor Live-Importen und Gerätewechseln eine vollständige lokale Sicherung.
+        </p>
+      </div>
+    </header>
+
+    <section class="warning-card" role="alert">
+      <h2>Wichtig</h2>
+      <p>
+        ViccoBoard speichert lokal im Browser. App-Dateien und lokale Daten sind getrennt.
+        Für Gerätewechsel brauchst Du eine Backup-Datei.
+      </p>
+    </section>
+
+    <div class="backup-grid">
+      <article class="backup-card">
+        <h2>Backup exportieren</h2>
+        <p>Exportiert alle lokalen ViccoBoard-Daten aus IndexedDB als JSON-Datei.</p>
+        <button type="button" :disabled="busy" @click="exportBackup">
+          Backup-Datei herunterladen
+        </button>
+      </article>
+
+      <article class="backup-card">
+        <h2>Backup wiederherstellen</h2>
+        <p>Importiert eine ViccoBoard-Backup-Datei. Es werden keine Stores geleert.</p>
+        <input
+          type="file"
+          accept="application/json,.json"
+          :disabled="busy"
+          @change="handleRestoreFile"
+        />
+      </article>
+    </div>
+
+    <p v-if="statusMessage" class="status-message" role="status">
+      {{ statusMessage }}
+    </p>
+    <p v-if="errorMessage" class="error-message" role="alert">
+      {{ errorMessage }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  buildBackupFileName,
+  createLiveDataBackup,
+  parseLiveDataBackup,
+  restoreLiveDataBackup
+} from '../services/live-data-backup.service'
+
+const busy = ref(false)
+const statusMessage = ref('')
+const errorMessage = ref('')
+
+async function exportBackup(): Promise<void> {
+  try {
+    busy.value = true
+    statusMessage.value = ''
+    errorMessage.value = ''
+
+    const backup = await createLiveDataBackup()
+    const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = buildBackupFileName()
+    link.click()
+    URL.revokeObjectURL(url)
+
+    statusMessage.value = 'Backup-Datei wurde erstellt.'
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Backup konnte nicht erstellt werden.'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function handleRestoreFile(event: Event): Promise<void> {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) {
+    return
+  }
+
+  const confirmed = window.confirm('Backup-Datei importieren?')
+  if (!confirmed) {
+    input.value = ''
+    return
+  }
+
+  try {
+    busy.value = true
+    statusMessage.value = ''
+    errorMessage.value = ''
+
+    const backup = parseLiveDataBackup(await file.text())
+    const result = await restoreLiveDataBackup(backup)
+    statusMessage.value = `${result.importedRecords} Datensätze aus ${result.importedStores} Bereichen importiert.`
+
+    if (result.skippedStores.length > 0) {
+      statusMessage.value += ` Übersprungen: ${result.skippedStores.join(', ')}.`
+    }
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Backup konnte nicht importiert werden.'
+  } finally {
+    busy.value = false
+    input.value = ''
+  }
+}
+</script>
+
+<style scoped>
+.backup-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header h1,
+.backup-card h2,
+.warning-card h2 {
+  margin: 0;
+}
+
+.subtitle,
+.backup-card p,
+.warning-card p {
+  color: #64748b;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #0f766e;
+  font-weight: 700;
+}
+
+.warning-card,
+.backup-card {
+  background: white;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  padding: 1.25rem;
+}
+
+.warning-card {
+  border-color: #f59e0b;
+  background: #fffbeb;
+}
+
+.backup-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.backup-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+button {
+  align-self: flex-start;
+  border: 0;
+  border-radius: 999px;
+  background: #0f766e;
+  color: white;
+  padding: 0.75rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.status-message,
+.error-message {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.status-message {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.error-message {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+</style>


### PR DESCRIPTION
## DONE
- Centralized the IndexedDB database name as `VICCOBOARD_DATABASE_NAME`.
- Added a local live-data backup service:
  - exports all current IndexedDB object stores into one ViccoBoard JSON backup file
  - parses and validates backup files by explicit format/version marker
  - restores only into existing stores
  - skips unknown stores instead of failing destructively
- Restore is differential and additive:
  - new records are inserted
  - existing records are merged field-by-field
  - arrays of objects with `id` are merged by item ID
  - arrays without item IDs are unioned by stable structural comparison
  - conflicting scalar changes are not overwritten silently; they are counted as conflicts and skipped for that field/record branch
  - no store is cleared during restore
- Added `Backups & Wiederherstellung` settings page.
- Enabled settings entry and route `/settings/backups`.
- No new dependency.
- No cloud sync.

## NOT DONE
- No automatic multi-device sync.
- No conflict resolution UI yet.
- No encrypted backup format yet.
- No backup reminder before CSV import yet.
- No tests added yet.
- No migration.

## CHECKS
- Repo-native paths checked before patching:
  - `storage.service.ts`
  - `indexeddb.storage.ts`
  - `indexeddb.adapter.ts`
  - `settings-sections.ts`
  - `router/index.ts`
- Scope check: manual backup/restore only.
- Local tests were not run in this environment.

## READY FOR NEXT STEP
NOT DONE - draft PR. Run typecheck/tests and then add focused tests for differential restore before merging to live.