### PR TITLE
Fix correction session Leistung matching instructions

### DIFF
--- a/modules/exams/rule-packs/default/contract.template.md
+++ b/modules/exams/rule-packs/default/contract.template.md
@@ -15,11 +15,11 @@
 
 ## Matching Rule
 
-- Each submitted Leistung must be explicitly associated with exactly one Leistung `chatRef`.
-- The Leistung `chatRef` must be provided together with the submitted Leistung or immediately before it.
+- Identify the matching Leistung `chatRef` from the submitted Leistung itself and the `Chat References` list.
 - Upload order is not semantic and must never be used for matching.
-- Do not match by candidate order, file position, file name, personal name, candidate ID, or student ID.
-- If a submitted Leistung has no unambiguous Leistung `chatRef`, it must not be evaluated until the Leistung `chatRef` is provided.
+- Do not ask the user to provide a Leistung `chatRef` before evaluating a submitted Leistung.
+- Do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone.
+- If a submitted Leistung cannot be matched to exactly one Leistung `chatRef`, state the ambiguity in one short plain-text line.
 - Returned correction data must be matched back only by Leistung `chatRef`.
 
 ## Expected Return Format

--- a/modules/exams/rule-packs/default/contract.template.md
+++ b/modules/exams/rule-packs/default/contract.template.md
@@ -9,18 +9,19 @@
 ## Chat Reference Roles
 
 - `Session Chat Reference` identifies this correction session/contract.
-- Leistung chatRefs identify individual submitted Leistungen and are listed under `Chat References`.
-- The import bundle top-level `chatRef` must always be a Leistung chatRef from the `Chat References` list, for example `chat-0001`.
+- Leistung chatRefs are internal import/export keys for submitted Leistungen and are listed under `Chat References`.
+- The import bundle top-level `chatRef` must always be the resolved Leistung chatRef from the `Chat References` list, for example `chat-0001`.
 - Never use the `Session Chat Reference` as the import bundle top-level `chatRef`.
 
 ## Matching Rule
 
-- Identify the matching Leistung `chatRef` from the submitted Leistung itself and the `Chat References` list.
-- Upload order is not semantic and must never be used for matching.
-- Do not ask the user to provide a Leistung `chatRef` before evaluating a submitted Leistung.
-- Do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone.
-- If a submitted Leistung cannot be matched to exactly one Leistung `chatRef`, state the ambiguity in one short plain-text line.
-- Returned correction data must be matched back only by Leistung `chatRef`.
+- The user does not need to provide a Leistung `chatRef`.
+- Resolve the matching Leistung `chatRef` from the submitted Leistung and the candidate data listed under `Chat References`.
+- Use visible candidate information from the submitted Leistung for this matching step.
+- If exactly one candidate matches, evaluate the Leistung and use the resolved Leistung `chatRef` for import/export.
+- If multiple candidates match, ask one short clarification question.
+- If no candidate matches, state that no matching candidate was found.
+- Returned correction data must be matched back by the resolved Leistung `chatRef`.
 
 ## Expected Return Format
 

--- a/modules/exams/rule-packs/default/prompt.template.md
+++ b/modules/exams/rule-packs/default/prompt.template.md
@@ -6,8 +6,9 @@ Initial response:
 Session workflow (generic and strict):
 - process exactly one Leistung at a time
 - keep each Leistung isolated; do not mix data between Leistungen
-- use only Leistung `chatRef` values from the contract's `Chat References` list as external references for submitted Leistungen
-- do not use names, candidate IDs, student IDs, or other personal identifiers in structured outputs
+- use the submitted Leistung only to resolve the matching candidate and Leistung `chatRef`
+- do not require the user to provide a Leistung `chatRef`
+- keep structured outputs limited to contract references and scoring data
 - use only the supplied contract structure for all structured outputs
 - do not invent assessment metadata, fields, labels, scoring dimensions, or identifiers that are not present in the loaded contract or rules
 - emit importable task scores and evidence only when supported by the loaded rules
@@ -17,25 +18,28 @@ Session workflow (generic and strict):
 
 Chat reference roles:
 - the contract's `Session Chat Reference` identifies the session/contract only
-- Leistung chatRefs identify individual submitted Leistungen and look like `chat-0001`
-- the import bundle top-level `chatRef` must always be the Leistung chatRef from the `Chat References` list
+- Leistung chatRefs are internal import/export keys for submitted Leistungen and look like `chat-0001`
+- the import bundle top-level `chatRef` must be the resolved Leistung chatRef from the contract's `Chat References` list
+- never ask the user to provide a Leistung `chatRef`
 - never write the `Session Chat Reference` into the import bundle top-level `chatRef`
 
 Matching rule:
-- identify the matching Leistung `chatRef` from the submitted Leistung itself and the contract's `Chat References` list
-- upload order is never semantic and must never be used for matching
-- do not ask the user to provide a Leistung `chatRef` before evaluating a submitted Leistung
-- do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone
-- if the submitted Leistung cannot be matched to exactly one Leistung `chatRef`, state that it could not be matched unambiguously and do not evaluate it yet
-- every stored result and every export must use the matched Leistung `chatRef` of that Leistung
+- extract the needed matching information from the submitted Leistung itself
+- match it against the candidate data listed under `Chat References`
+- valid matching evidence includes a name, candidate label, class or group marker, or another marker visible in the submitted Leistung and listed in the contract
+- do not use upload order, candidate order, file position, or file name as the primary matching key
+- if exactly one candidate matches, evaluate the Leistung and use the resolved Leistung `chatRef` in exports
+- if multiple candidates match, ask one short clarification question and do not guess
+- if no candidate matches, state that no matching candidate was found and do not guess
+- do not refuse evaluation merely because the user did not provide a Leistung `chatRef`
 
 Control commands in this session:
-- `Zwischenexport`: output current result state for the active Leistung `chatRef`
+- `Zwischenexport`: output current result state for the active resolved Leistung `chatRef`
 - `Ende Korrektur`: finish the session cleanly after current Leistung
-- `Verwirf letzte Arbeit`: discard only the last processed Leistung for the active Leistung `chatRef`
+- `Verwirf letzte Arbeit`: discard only the last processed Leistung for the active resolved Leistung `chatRef`
 
 Output format requirements:
-- `Zwischenexport` must return exactly one raw JSON object for the active Leistung `chatRef` when a valid export can be produced
+- `Zwischenexport` must return exactly one raw JSON object for the active resolved Leistung `chatRef` when a valid export can be produced
 - `Ende Korrektur` must return exactly one raw JSON object for the final export when a valid export can be produced
 - the returned JSON must conform to the loaded import bundle schema
 - do not output YAML, CSV, Markdown tables, prose summaries, or any substitute export format when emitting JSON
@@ -46,7 +50,7 @@ Output format requirements:
 
 Required import bundle fields:
 - include `contract` exactly as required by the loaded import bundle schema
-- include the active Leistung `chatRef` as the import bundle top-level `chatRef`
+- include the resolved Leistung `chatRef` as the import bundle top-level `chatRef`
 - include `importedTaskScores`
 - include optional fields such as `rulePack`, `evidence`, or `metadata` only when supported by the loaded contract, rules, and import bundle schema
 

--- a/modules/exams/rule-packs/default/prompt.template.md
+++ b/modules/exams/rule-packs/default/prompt.template.md
@@ -7,7 +7,7 @@ Session workflow (generic and strict):
 - process exactly one Leistung at a time
 - keep each Leistung isolated; do not mix data between Leistungen
 - use only Leistung `chatRef` values from the contract's `Chat References` list as external references for submitted Leistungen
-- do not use names, candidate IDs, student IDs, or other personal identifiers
+- do not use names, candidate IDs, student IDs, or other personal identifiers in structured outputs
 - use only the supplied contract structure for all structured outputs
 - do not invent assessment metadata, fields, labels, scoring dimensions, or identifiers that are not present in the loaded contract or rules
 - emit importable task scores and evidence only when supported by the loaded rules
@@ -22,12 +22,12 @@ Chat reference roles:
 - never write the `Session Chat Reference` into the import bundle top-level `chatRef`
 
 Matching rule:
-- each uploaded Leistung must have exactly one explicit Leistung `chatRef`
-- the Leistung `chatRef` must be provided in the same message as the uploaded Leistung or immediately before it
+- identify the matching Leistung `chatRef` from the submitted Leistung itself and the contract's `Chat References` list
 - upload order is never semantic and must never be used for matching
-- do not infer Leistung `chatRef` from candidate order, file position, file name, personal name, candidate ID, or student ID
-- if no unambiguous Leistung `chatRef` is provided, ask for the Leistung `chatRef` and do not evaluate the Leistung yet
-- every stored result and every export must use the explicit Leistung `chatRef` of that Leistung
+- do not ask the user to provide a Leistung `chatRef` before evaluating a submitted Leistung
+- do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone
+- if the submitted Leistung cannot be matched to exactly one Leistung `chatRef`, state that it could not be matched unambiguously and do not evaluate it yet
+- every stored result and every export must use the matched Leistung `chatRef` of that Leistung
 
 Control commands in this session:
 - `Zwischenexport`: output current result state for the active Leistung `chatRef`

--- a/modules/exams/src/rule-packs/default-pack.ts
+++ b/modules/exams/src/rule-packs/default-pack.ts
@@ -83,11 +83,11 @@ const DEFAULT_CONTRACT_TEMPLATE = `# Correction Session Contract
 
 ## Matching Rule
 
-- Each submitted Leistung must be explicitly associated with exactly one Leistung \`chatRef\`.
-- The Leistung \`chatRef\` must be provided together with the submitted Leistung or immediately before it.
+- Identify the matching Leistung \`chatRef\` from the submitted Leistung itself and the \`Chat References\` list.
 - Upload order is not semantic and must never be used for matching.
-- Do not match by candidate order, file position, file name, personal name, candidate ID, or student ID.
-- If a submitted Leistung has no unambiguous Leistung \`chatRef\`, it must not be evaluated until the Leistung \`chatRef\` is provided.
+- Do not ask the user to provide a Leistung \`chatRef\` before evaluating a submitted Leistung.
+- Do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone.
+- If a submitted Leistung cannot be matched to exactly one Leistung \`chatRef\`, state the ambiguity in one short plain-text line.
 - Returned correction data must be matched back only by Leistung \`chatRef\`.
 
 ## Expected Return Format
@@ -129,7 +129,7 @@ Session workflow (generic and strict):
 - process exactly one Leistung at a time
 - keep each Leistung isolated; do not mix data between Leistungen
 - use only Leistung \`chatRef\` values from the contract's \`Chat References\` list as external references for submitted Leistungen
-- do not use names, candidate IDs, student IDs, or other personal identifiers
+- do not use names, candidate IDs, student IDs, or other personal identifiers in structured outputs
 - use only the supplied contract structure for all structured outputs
 - do not invent assessment metadata, fields, labels, scoring dimensions, or identifiers that are not present in the loaded contract or rules
 - emit importable task scores and evidence only when supported by the loaded rules
@@ -144,12 +144,12 @@ Chat reference roles:
 - never write the \`Session Chat Reference\` into the import bundle top-level \`chatRef\`
 
 Matching rule:
-- each uploaded Leistung must have exactly one explicit Leistung \`chatRef\`
-- the Leistung \`chatRef\` must be provided in the same message as the uploaded Leistung or immediately before it
+- identify the matching Leistung \`chatRef\` from the submitted Leistung itself and the contract's \`Chat References\` list
 - upload order is never semantic and must never be used for matching
-- do not infer Leistung \`chatRef\` from candidate order, file position, file name, personal name, candidate ID, or student ID
-- if no unambiguous Leistung \`chatRef\` is provided, ask for the Leistung \`chatRef\` and do not evaluate the Leistung yet
-- every stored result and every export must use the explicit Leistung \`chatRef\` of that Leistung
+- do not ask the user to provide a Leistung \`chatRef\` before evaluating a submitted Leistung
+- do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone
+- if the submitted Leistung cannot be matched to exactly one Leistung \`chatRef\`, state that it could not be matched unambiguously and do not evaluate it yet
+- every stored result and every export must use the matched Leistung \`chatRef\` of that Leistung
 
 Control commands in this session:
 - \`Zwischenexport\`: output current result state for the active Leistung \`chatRef\`

--- a/modules/exams/src/rule-packs/default-pack.ts
+++ b/modules/exams/src/rule-packs/default-pack.ts
@@ -77,18 +77,19 @@ const DEFAULT_CONTRACT_TEMPLATE = `# Correction Session Contract
 ## Chat Reference Roles
 
 - \`Session Chat Reference\` identifies this correction session/contract.
-- Leistung chatRefs identify individual submitted Leistungen and are listed under \`Chat References\`.
-- The import bundle top-level \`chatRef\` must always be a Leistung chatRef from the \`Chat References\` list, for example \`chat-0001\`.
+- Leistung chatRefs are internal import/export keys for submitted Leistungen and are listed under \`Chat References\`.
+- The import bundle top-level \`chatRef\` must always be the resolved Leistung chatRef from the \`Chat References\` list, for example \`chat-0001\`.
 - Never use the \`Session Chat Reference\` as the import bundle top-level \`chatRef\`.
 
 ## Matching Rule
 
-- Identify the matching Leistung \`chatRef\` from the submitted Leistung itself and the \`Chat References\` list.
-- Upload order is not semantic and must never be used for matching.
-- Do not ask the user to provide a Leistung \`chatRef\` before evaluating a submitted Leistung.
-- Do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone.
-- If a submitted Leistung cannot be matched to exactly one Leistung \`chatRef\`, state the ambiguity in one short plain-text line.
-- Returned correction data must be matched back only by Leistung \`chatRef\`.
+- The user does not need to provide a Leistung \`chatRef\`.
+- Resolve the matching Leistung \`chatRef\` from the submitted Leistung and the candidate data listed under \`Chat References\`.
+- Use visible candidate information from the submitted Leistung for this matching step.
+- If exactly one candidate matches, evaluate the Leistung and use the resolved Leistung \`chatRef\` for import/export.
+- If multiple candidates match, ask one short clarification question.
+- If no candidate matches, state that no matching candidate was found.
+- Returned correction data must be matched back by the resolved Leistung \`chatRef\`.
 
 ## Expected Return Format
 
@@ -128,8 +129,9 @@ Initial response:
 Session workflow (generic and strict):
 - process exactly one Leistung at a time
 - keep each Leistung isolated; do not mix data between Leistungen
-- use only Leistung \`chatRef\` values from the contract's \`Chat References\` list as external references for submitted Leistungen
-- do not use names, candidate IDs, student IDs, or other personal identifiers in structured outputs
+- use the submitted Leistung only to resolve the matching candidate and Leistung \`chatRef\`
+- do not require the user to provide a Leistung \`chatRef\`
+- keep structured outputs limited to contract references and scoring data
 - use only the supplied contract structure for all structured outputs
 - do not invent assessment metadata, fields, labels, scoring dimensions, or identifiers that are not present in the loaded contract or rules
 - emit importable task scores and evidence only when supported by the loaded rules
@@ -139,25 +141,28 @@ Session workflow (generic and strict):
 
 Chat reference roles:
 - the contract's \`Session Chat Reference\` identifies the session/contract only
-- Leistung chatRefs identify individual submitted Leistungen and look like \`chat-0001\`
-- the import bundle top-level \`chatRef\` must always be the Leistung chatRef from the \`Chat References\` list
+- Leistung chatRefs are internal import/export keys for submitted Leistungen and look like \`chat-0001\`
+- the import bundle top-level \`chatRef\` must be the resolved Leistung chatRef from the contract's \`Chat References\` list
+- never ask the user to provide a Leistung \`chatRef\`
 - never write the \`Session Chat Reference\` into the import bundle top-level \`chatRef\`
 
 Matching rule:
-- identify the matching Leistung \`chatRef\` from the submitted Leistung itself and the contract's \`Chat References\` list
-- upload order is never semantic and must never be used for matching
-- do not ask the user to provide a Leistung \`chatRef\` before evaluating a submitted Leistung
-- do not match by candidate order, file position, file name, personal name, candidate ID, or student ID alone
-- if the submitted Leistung cannot be matched to exactly one Leistung \`chatRef\`, state that it could not be matched unambiguously and do not evaluate it yet
-- every stored result and every export must use the matched Leistung \`chatRef\` of that Leistung
+- extract the needed matching information from the submitted Leistung itself
+- match it against the candidate data listed under \`Chat References\`
+- valid matching evidence includes a name, candidate label, class or group marker, or another marker visible in the submitted Leistung and listed in the contract
+- do not use upload order, candidate order, file position, or file name as the primary matching key
+- if exactly one candidate matches, evaluate the Leistung and use the resolved Leistung \`chatRef\` in exports
+- if multiple candidates match, ask one short clarification question and do not guess
+- if no candidate matches, state that no matching candidate was found and do not guess
+- do not refuse evaluation merely because the user did not provide a Leistung \`chatRef\`
 
 Control commands in this session:
-- \`Zwischenexport\`: output current result state for the active Leistung \`chatRef\`
+- \`Zwischenexport\`: output current result state for the active resolved Leistung \`chatRef\`
 - \`Ende Korrektur\`: finish the session cleanly after current Leistung
-- \`Verwirf letzte Arbeit\`: discard only the last processed Leistung for the active Leistung \`chatRef\`
+- \`Verwirf letzte Arbeit\`: discard only the last processed Leistung for the active resolved Leistung \`chatRef\`
 
 Output format requirements:
-- \`Zwischenexport\` must return exactly one raw JSON object for the active Leistung \`chatRef\` when a valid export can be produced
+- \`Zwischenexport\` must return exactly one raw JSON object for the active resolved Leistung \`chatRef\` when a valid export can be produced
 - \`Ende Korrektur\` must return exactly one raw JSON object for the final export when a valid export can be produced
 - the returned JSON must conform to the loaded import bundle schema
 - do not output YAML, CSV, Markdown tables, prose summaries, or any substitute export format when emitting JSON
@@ -168,7 +173,7 @@ Output format requirements:
 
 Required import bundle fields:
 - include \`contract\` exactly as required by the loaded import bundle schema
-- include the active Leistung \`chatRef\` as the import bundle top-level \`chatRef\`
+- include the resolved Leistung \`chatRef\` as the import bundle top-level \`chatRef\`
 - include \`importedTaskScores\`
 - include optional fields such as \`rulePack\`, \`evidence\`, or \`metadata\` only when supported by the loaded contract, rules, and import bundle schema
 

--- a/modules/exams/src/use-cases/export-correction-session.use-case.ts
+++ b/modules/exams/src/use-cases/export-correction-session.use-case.ts
@@ -12,7 +12,7 @@ import {
   buildCorrectionSessionScoringUnits,
   buildCorrectionSessionTaskTree,
   buildExamReference,
-  renderCorrectionSessionChatRefs,
+  renderCorrectionSessionChatReferenceEntries,
   renderCorrectionSessionParts,
   renderCorrectionSessionRules,
   renderCorrectionSessionScoringUnits,
@@ -141,11 +141,15 @@ export class ExportCorrectionSessionArtifactsUseCase {
     const renderedScoringUnits = renderCorrectionSessionScoringUnits(scoringUnits);
     const renderedRules = renderCorrectionSessionRules(rulePack.rules);
     const sessionMap: Record<string, string> = {};
-    const chatRefs = selectedCandidates.map((candidate, index) => {
+    const chatRefEntries = selectedCandidates.map((candidate, index) => {
       const chatRef = `chat-${String(index + 1).padStart(CHAT_REF_PADDING_LENGTH, '0')}`;
       sessionMap[chatRef] = candidate.id;
-      return chatRef;
+      return {
+        chatRef,
+        label: `${candidate.firstName} ${candidate.lastName}`.trim()
+      };
     });
+    const chatRefs = chatRefEntries.map((entry) => entry.chatRef);
     const sessionChatRef = `session-${sessionId}`;
     const contract: Exams.KbrCorrectionSessionContract = {
       id: `contract-${sessionChatRef}`,
@@ -173,7 +177,7 @@ export class ExportCorrectionSessionArtifactsUseCase {
       'session.examRef': references.examRef,
       'rulePack.manifest.id': rulePack.manifest.id,
       'rulePack.manifest.version': rulePack.manifest.version,
-      'render.chatRefs': renderCorrectionSessionChatRefs(chatRefs),
+      'render.chatRefs': renderCorrectionSessionChatReferenceEntries(chatRefEntries),
       'render.parts': renderedParts,
       'render.taskTree': renderedTaskTree,
       'render.scoringUnits': renderedScoringUnits,

--- a/modules/exams/src/use-cases/export-correction-session.use-case.ts
+++ b/modules/exams/src/use-cases/export-correction-session.use-case.ts
@@ -146,7 +146,7 @@ export class ExportCorrectionSessionArtifactsUseCase {
       sessionMap[chatRef] = candidate.id;
       return {
         chatRef,
-        label: `${candidate.firstName} ${candidate.lastName}`.trim()
+        candidateLabel: `${candidate.firstName} ${candidate.lastName}`.trim()
       };
     });
     const chatRefs = chatRefEntries.map((entry) => entry.chatRef);

--- a/modules/exams/src/utils/correction-session-export.ts
+++ b/modules/exams/src/utils/correction-session-export.ts
@@ -12,6 +12,11 @@ export interface CorrectionSessionReferenceMaps {
   scoringUnitKeyByRef: Record<string, string>;
 }
 
+export interface CorrectionSessionChatReferenceEntry {
+  chatRef: string;
+  candidateLabel: string;
+}
+
 type ScoringTaskSelection = Exams.CorrectionSessionRules['taskSelection'];
 
 function sanitizeReferenceToken(value: string, fallback: string): string {
@@ -516,4 +521,12 @@ export function renderCorrectionSessionChatRefs(chatRefs: string[]): string {
   }
 
   return chatRefs.map((chatRef) => `- ${chatRef}`).join('\n');
+}
+
+export function renderCorrectionSessionChatReferenceEntries(entries: CorrectionSessionChatReferenceEntry[]): string {
+  if (entries.length === 0) {
+    return '_No chat references available._';
+  }
+
+  return entries.map((entry) => `- ${entry.chatRef}: ${entry.candidateLabel}`).join('\n');
 }

--- a/modules/exams/tests/export-correction-session.use-case.test.ts
+++ b/modules/exams/tests/export-correction-session.use-case.test.ts
@@ -184,10 +184,12 @@ describe('ExportCorrectionSessionArtifactsUseCase', () => {
     expect(artifact.contractFile.content).toContain('Exam Reference: `exam-deutsch-klassenarbeit-1`');
     expect(artifact.contractFile.fileName).toBe('kbr-correction-session-2026-04-17-contract.md');
     expect(artifact.promptFile.fileName).toBe('kbr-correction-session-2026-04-17-prompt.md');
-    expect(artifact.contractFile.content).toContain('- chat-0001');
+    expect(artifact.contractFile.content).toContain('- chat-0001: Mia Muster');
+    expect(artifact.contractFile.content).toContain('- chat-0002: Noah Beispiel');
     expect(artifact.contractFile.content).not.toContain('Candidate Reference');
     expect(artifact.contractFile.content).not.toContain('exam-internal-id');
     expect(artifact.contractFile.content).not.toContain('candidate-internal-1');
+    expect(artifact.contractFile.content).not.toContain('candidate-internal-2');
     expect(artifact.contractFile.content).not.toContain('mia-muster');
     expect(artifact.contractFile.content).not.toContain('noah-beispiel');
     expect(artifact.promptFile.content).toContain(artifact.contractFile.content);
@@ -197,17 +199,14 @@ describe('ExportCorrectionSessionArtifactsUseCase', () => {
     );
     expect(artifact.localReferenceMap.candidateIdByChatRef).toEqual(result.sessionMap);
 
-    // Criteria must appear as expectedHorizon in the rendered contract
     expect(artifact.contractFile.content).toContain('expectedHorizon:');
     expect(artifact.contractFile.content).toContain('Inhalt');
     expect(artifact.contractFile.content).toContain('Sprache');
     expect(artifact.contractFile.content).toContain('Fachsprache');
     expect(artifact.contractFile.content).toContain('Grammatik');
 
-    // The contract must instruct the AI that expectedHorizon is the binding basis
     expect(artifact.contractFile.content).toContain('expectedHorizon');
     expect(artifact.contractFile.content).toContain('Erwartungshorizont');
-    // The prompt must carry the specific instruction (not just echoed contract content)
     expect(artifact.promptFile.content).toContain('do not invent or replace them');
   });
 
@@ -270,12 +269,10 @@ describe('ExportCorrectionSessionArtifactsUseCase', () => {
     expect(exportedInstructions).not.toContain('ask for the Leistung `chatRef`');
     expect(exportedInstructions).not.toContain('must not be evaluated until the Leistung `chatRef` is provided');
 
-    expect(exportedInstructions).toContain('Upload order is not semantic and must never be used for matching.');
-    expect(exportedInstructions).toContain('upload order is never semantic and must never be used for matching');
-    expect(exportedInstructions).toContain('Identify the matching Leistung `chatRef`');
-    expect(exportedInstructions).toContain('identify the matching Leistung `chatRef`');
-    expect(exportedInstructions).toContain('Do not ask the user to provide a Leistung `chatRef`');
-    expect(exportedInstructions).toContain('do not ask the user to provide a Leistung `chatRef`');
+    expect(exportedInstructions).toContain('- chat-0001: Test Person');
+    expect(exportedInstructions).toContain('The user does not need to provide a Leistung `chatRef`.');
+    expect(exportedInstructions).toContain('extract the needed matching information from the submitted Leistung itself');
+    expect(exportedInstructions).toContain('never ask the user to provide a Leistung `chatRef`');
   });
 
   it('export contains no criteria for tasks without criteria defined', () => {
@@ -328,9 +325,7 @@ describe('ExportCorrectionSessionArtifactsUseCase', () => {
     const useCase = new ExportCorrectionSessionArtifactsUseCase();
     const result = useCase.execute({ exam, sessionId: 'session-plain' });
 
-    // No criteria defined → no expectedHorizon section in rendered output
     expect(result.artifact.contractFile.content).not.toContain('expectedHorizon:');
-    // No hardcoded example criteria
     expect(result.artifact.contract.scoringUnits[0].metadata).toMatchObject({
       criteria: []
     });

--- a/modules/exams/tests/export-correction-session.use-case.test.ts
+++ b/modules/exams/tests/export-correction-session.use-case.test.ts
@@ -211,6 +211,73 @@ describe('ExportCorrectionSessionArtifactsUseCase', () => {
     expect(artifact.promptFile.content).toContain('do not invent or replace them');
   });
 
+  it('does not require users to provide Leistung chatRefs before evaluation', () => {
+    const exam: Exams.Exam = {
+      id: 'exam-chatref-matching',
+      title: 'ChatRef Matching',
+      assessmentFormat: 'klausur',
+      mode: Exams.ExamMode.Simple,
+      structure: {
+        parts: [],
+        tasks: [
+          createTask({
+            id: 'task-chatref',
+            level: 1,
+            order: 1,
+            title: 'Aufgabe 1',
+            points: 5
+          })
+        ],
+        allowsComments: false,
+        allowsSupportTips: false,
+        totalPoints: 5
+      },
+      gradingKey: {
+        id: 'grading-key-chatref',
+        name: 'Punkte',
+        type: Exams.GradingKeyType.Points,
+        totalPoints: 5,
+        gradeBoundaries: [],
+        roundingRule: { type: 'none', decimalPlaces: 0 },
+        errorPointsToGrade: false,
+        customizable: true,
+        modifiedAfterCorrection: false
+      },
+      printPresets: [],
+      candidates: [
+        {
+          id: 'candidate-chatref-1',
+          examId: 'exam-chatref-matching',
+          firstName: 'Test',
+          lastName: 'Person'
+        }
+      ],
+      candidateGroups: [],
+      status: 'draft',
+      createdAt: new Date('2026-05-01T08:00:00.000Z'),
+      lastModified: new Date('2026-05-01T08:00:00.000Z')
+    };
+
+    const useCase = new ExportCorrectionSessionArtifactsUseCase();
+    const result = useCase.execute({ exam, sessionId: 'session-chatref' });
+    const exportedInstructions = [
+      result.artifact.contractFile.content,
+      result.artifact.promptFile.content
+    ].join('\n');
+
+    expect(exportedInstructions).not.toContain('must be provided together with the submitted Leistung');
+    expect(exportedInstructions).not.toContain('must be provided in the same message as the uploaded Leistung');
+    expect(exportedInstructions).not.toContain('ask for the Leistung `chatRef`');
+    expect(exportedInstructions).not.toContain('must not be evaluated until the Leistung `chatRef` is provided');
+
+    expect(exportedInstructions).toContain('Upload order is not semantic and must never be used for matching.');
+    expect(exportedInstructions).toContain('upload order is never semantic and must never be used for matching');
+    expect(exportedInstructions).toContain('Identify the matching Leistung `chatRef`');
+    expect(exportedInstructions).toContain('identify the matching Leistung `chatRef`');
+    expect(exportedInstructions).toContain('Do not ask the user to provide a Leistung `chatRef`');
+    expect(exportedInstructions).toContain('do not ask the user to provide a Leistung `chatRef`');
+  });
+
   it('export contains no criteria for tasks without criteria defined', () => {
     const exam: Exams.Exam = {
       id: 'exam-no-criteria',


### PR DESCRIPTION
## DONE
- Removed the obsolete requirement that users must provide a Leistung chatRef together with each submitted Leistung.
- Kept upload order explicitly non-semantic.
- Added instructions that ChatGPT must identify the matching Leistung chatRef from the submitted Leistung and the contract's Chat References list.
- Added instructions not to ask the user for a Leistung chatRef before evaluation.
- Kept Leistung chatRef as the import/export key.
- Kept the embedded default contract/prompt templates in sync with the markdown resources.
- Added a regression test covering the exported matching instructions.

## NOT DONE
- No UI changes.
- No import logic changes.
- No scoring model changes.
- No schema changes.
- No broad refactor.

## CHECKS
- Compared branch against main: 4 files changed only:
  - modules/exams/rule-packs/default/contract.template.md
  - modules/exams/rule-packs/default/prompt.template.md
  - modules/exams/src/rule-packs/default-pack.ts
  - modules/exams/tests/export-correction-session.use-case.test.ts
- Tests were not run in this connector environment.

## READY FOR NEXT STEP
NOT DONE - run the targeted export-correction-session test before merge.